### PR TITLE
Use correct workspace id header

### DIFF
--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -52,7 +52,7 @@ class BigeyeAPIClient:
         
         # Add workspace_id as a header if configured
         if self.workspace_id:
-            headers["X-Workspace-Id"] = str(self.workspace_id)
+            headers["x-bigeye-workspace-id"] = str(self.workspace_id)
         
         # Verbose logging for ALL requests
         print(f"\n[BIGEYE API VERBOSE] === REQUEST DETAILS ===", file=sys.stderr)


### PR DESCRIPTION
Some API calls, like the lineage node search, were not working because we were not setting the correct name for the workspace id header property.