### PR TITLE
Set up getting upstream issues for a report

### DIFF
--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -283,6 +283,23 @@ class BigeyeAPIClient:
             method="POST",
             json_data=payload
         )
+
+    async def get_upstream_issues_for_report(
+        self,
+        report_id: int
+    ) -> Dict[str, Any]:
+        """Get upstream issues for a BI report (like a Tableau workbook)
+
+        Args:
+            report_id: The ID of the BI report to get upstream issues for
+
+        Returns:
+            Dictionary containing the upstream issues of the desired report
+        """
+        return await self.make_request(
+            f"/api/v2/lineage/nodes/{report_id}/upstream-issues",
+            method="GET"
+        )
         
     async def get_issue_resolution_steps(
         self,
@@ -584,6 +601,8 @@ class BigeyeAPIClient:
         node_type: Optional[str] = None
     ) -> Dict[str, Any]:
         """Find a lineage node by name.
+           Note: do not include asterisks to search.
+           The server includes wildcards automatically.
         
         Args:
             node_name: Name of the node to find

--- a/tests/fixtures/mcp_messages.json
+++ b/tests/fixtures/mcp_messages.json
@@ -39,6 +39,7 @@
       "analyze_upstream_root_causes",
       "analyze_downstream_impact",
       "get_lineage_node_issues",
+      "get_upstream_issues_for_report",
       "trace_issue_lineage_path"
     ]
   },


### PR DESCRIPTION
Here, I added a method to hit our new endpoint for upstream issues of a report. I also had to change the instructions on finding lineage nodes, since that wasn't working correctly either.