### PR TITLE
Get related issues

### DIFF
--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -148,6 +148,25 @@ class BigeyeAPIClient:
                 "status": "error",
                 "message": str(e)
             }
+
+    async def fetch_related_issues(
+        self,
+        starting_issue_id: int
+    ) -> Dict[str, Any]:
+        """Fetch related issues for an issue. This will include upstream and downstream issues.
+
+        Args:
+            starting_issue_id: The issues for which to get the related issues
+
+        Returns:
+            Dictionary containing the related issues
+        """
+        print(f"[BIGEYE API DEBUG] Fetching related issues for issue {starting_issue_id}", file=sys.stderr)
+
+        return await self.make_request(
+            f"/api/v1/issues/{starting_issue_id}/suggested-merge",
+            method="GET"
+        )
             
     async def fetch_issues(
         self,


### PR DESCRIPTION
This adds support for getting the related issues, which includes getting root cause issues. This is important for the user being able to start at, for instance, a report and get all of the upstream issues as well as their root causes.

Here's some sample output from Claude where it was able to use it.

<img width="744" height="784" alt="image" src="https://github.com/user-attachments/assets/5ec14ceb-e6d6-4bb2-98c0-8451fb9dfa5f" />
