### PR TITLE
Filter issues by assignee + add get_current_user tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ To connect to multiple Bigeye instances (e.g. demo and production), create separ
 
 ### Issue Management
 
-- **`list_issues`** — List data quality issues across the workspace
+- **`list_issues`** — List data quality issues across the workspace (filter by status, schema, or `assignee_ids`)
+- **`get_current_user`** — Get the authenticated user (id, email, name, workspaces); pair with `list_issues(assignee_ids=[id])` to find issues assigned to you
 - **`get_issue`** — Get full details for a single issue by its internal ID
 - **`search_issues`** — Find issues by their display name/number (e.g. "10921")
 - **`list_related_issues`** — List issues related to a given issue via lineage

--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -185,7 +185,7 @@ class BigeyeAPIClient:
         workspace_id: int,
         currentStatus: Optional[List[str]] = None,
         schemaNames: Optional[List[str]] = None,
-        assignee_ids: Optional[List[int]] = None,
+        assigneeIds: Optional[List[int]] = None,
         page_size: Optional[int] = None,
         page_cursor: Optional[str] = None,
         include_full_history: bool = False,
@@ -199,13 +199,16 @@ class BigeyeAPIClient:
             currentStatus: Optional list of issue statuses to filter by
                 (e.g., ["ISSUE_STATUS_NEW", "ISSUE_STATUS_ACKNOWLEDGED"])
             schemaNames: Optional list of schema names to filter issues by
-            assignee_ids: Optional list of integer user IDs to filter issues by assignee.
+            assigneeIds: Optional list of integer user IDs to filter issues by assignee.
                 Use fetch_current_user() to resolve the current user's ID.
             page_size: Optional number of issues to return per page
             page_cursor: Cursor for pagination
             include_full_history: If False, strips out historical metric runs to reduce data size
             compact: If True, returns only minimal fields (id, name, status, table, schema).
-                    Use this for listing issues, then fetch details for specific issues.
+                    When an issue has an assignee, the output also includes `assignee`
+                    (name/email) and `assigneeId` (integer ID) — useful for verifying
+                    assignee filtering. Use this for listing issues, then fetch details
+                    for specific issues.
             max_issues: Maximum number of issues to return. If there are more issues,
                        the response will include truncation info. Helps prevent context overload.
 
@@ -229,8 +232,8 @@ class BigeyeAPIClient:
         if schemaNames:
             payload["schemaNames"] = schemaNames
 
-        if assignee_ids:
-            payload["assigneeIds"] = assignee_ids
+        if assigneeIds:
+            payload["assigneeIds"] = assigneeIds
 
         if page_cursor:
             payload["pageCursor"] = page_cursor

--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -168,11 +168,24 @@ class BigeyeAPIClient:
             method="GET"
         )
             
+    async def fetch_current_user(self) -> Dict[str, Any]:
+        """Fetch the currently authenticated user from the /auth endpoint.
+
+        Returns the UserAuth payload, which includes the integer user ``id``,
+        ``email``, ``name``, ``companyId``, and the list of accessible workspaces.
+        Use the returned ``id`` to filter issues by assignee via fetch_issues().
+
+        Returns:
+            Dictionary containing the current user's authentication/profile info
+        """
+        return await self.make_request("/auth", method="GET")
+
     async def fetch_issues(
         self,
         workspace_id: int,
         currentStatus: Optional[List[str]] = None,
         schemaNames: Optional[List[str]] = None,
+        assignee_ids: Optional[List[int]] = None,
         page_size: Optional[int] = None,
         page_cursor: Optional[str] = None,
         include_full_history: bool = False,
@@ -186,6 +199,8 @@ class BigeyeAPIClient:
             currentStatus: Optional list of issue statuses to filter by
                 (e.g., ["ISSUE_STATUS_NEW", "ISSUE_STATUS_ACKNOWLEDGED"])
             schemaNames: Optional list of schema names to filter issues by
+            assignee_ids: Optional list of integer user IDs to filter issues by assignee.
+                Use fetch_current_user() to resolve the current user's ID.
             page_size: Optional number of issues to return per page
             page_cursor: Cursor for pagination
             include_full_history: If False, strips out historical metric runs to reduce data size
@@ -213,6 +228,9 @@ class BigeyeAPIClient:
 
         if schemaNames:
             payload["schemaNames"] = schemaNames
+
+        if assignee_ids:
+            payload["assigneeIds"] = assignee_ids
 
         if page_cursor:
             payload["pageCursor"] = page_cursor
@@ -264,6 +282,11 @@ class BigeyeAPIClient:
                     "isIncident": issue.get("issueType") == "ISSUE_TYPE_INCIDENT" or issue.get("isIncident", False),
                     "alertCount": issue.get("alertCount"),
                 }
+                # Include assignee id/name if present
+                assignee = issue.get("assignee")
+                if assignee:
+                    compact_issue["assignee"] = assignee.get("name") or assignee.get("email")
+                    compact_issue["assigneeId"] = assignee.get("id")
                 compact_issues.append(compact_issue)
 
             # Normalize to always use "issues" key in output
@@ -298,10 +321,11 @@ class BigeyeAPIClient:
                     "openedTimeSeconds": issue.get("openedTimeSeconds"),
                 }
 
-                # Add assignee name if present
+                # Add assignee name/id if present
                 assignee = issue.get("assignee")
                 if assignee:
                     filtered_issue["assignee"] = assignee.get("name") or assignee.get("email")
+                    filtered_issue["assigneeId"] = assignee.get("id")
 
                 # Add only the most recent event summary if events exist
                 events = issue.get("events", [])

--- a/server.py
+++ b/server.py
@@ -837,6 +837,9 @@ async def list_issues(
         page_size: Optional number of issues to request from API per page (default: 20)
         page_cursor: Cursor for pagination
         compact: If True (default), returns only minimal fields (id, name, status, table, schema).
+                When an issue has an assignee, the output also includes `assignee`
+                (name/email) and `assigneeId` (integer ID) — useful for verifying
+                assignee filtering.
                 If False, returns standard fields including description and metric info.
                 Use compact=True to list issues, then get_issue() for specifics.
         max_issues: Maximum number of issues to return (default: 15). Prevents context overload.
@@ -868,7 +871,7 @@ async def list_issues(
         workspace_id=workspace_id,
         currentStatus=statuses,
         schemaNames=schema_names,
-        assignee_ids=assignee_ids,
+        assigneeIds=assignee_ids,
         page_size=page_size if page_size else 20,
         page_cursor=page_cursor,
         include_full_history=False,

--- a/server.py
+++ b/server.py
@@ -791,15 +791,37 @@ async def get_health_status() -> Dict[str, Any]:
     return result
 
 @mcp.tool()
+async def get_current_user() -> Dict[str, Any]:
+    """Get the currently authenticated Bigeye user (the API key owner). Returns their integer 'id', email, name, and accessible workspaces. Use this to answer 'who am I' and to resolve the current user's ID for assignee filtering — e.g. to find issues assigned to the current user, call this, then list_issues(assignee_ids=[id])."""
+
+    client = get_api_client()
+
+    debug_print("Fetching current authenticated user")
+    result = await client.fetch_current_user()
+
+    if result.get("error"):
+        return result
+
+    # Return a trimmed view of the UserAuth payload with the fields callers need
+    return {
+        "id": result.get("id"),
+        "email": result.get("email"),
+        "name": result.get("name"),
+        "companyId": result.get("companyId"),
+        "workspaces": result.get("workspaces"),
+    }
+
+@mcp.tool()
 async def list_issues(
     statuses: Optional[List[str]] = None,
     schema_names: Optional[List[str]] = None,
+    assignee_ids: Optional[List[int]] = None,
     page_size: Optional[int] = None,
     page_cursor: Optional[str] = None,
     compact: bool = True,
     max_issues: Optional[int] = 15
 ) -> Dict[str, Any]:
-    """List data quality issues across the workspace. Supports filtering by status (ISSUE_STATUS_NEW, ISSUE_STATUS_ACKNOWLEDGED, ISSUE_STATUS_CLOSED, ISSUE_STATUS_MONITORING, ISSUE_STATUS_MERGED) and schema. Returns compact summaries by default. Best for broad views like 'show all open issues'. For issues on a specific table, use list_table_issues instead.
+    """List data quality issues across the workspace. Supports filtering by status (ISSUE_STATUS_NEW, ISSUE_STATUS_ACKNOWLEDGED, ISSUE_STATUS_CLOSED, ISSUE_STATUS_MONITORING, ISSUE_STATUS_MERGED), schema, and assignee. Returns compact summaries by default. Best for broad views like 'show all open issues'. To find issues assigned to the current user, first call get_current_user to get their integer 'id', then pass it as assignee_ids=[id]. For issues on a specific table, use list_table_issues instead.
 
     Args:
         statuses: Optional list of issue statuses to filter by. Possible values:
@@ -809,6 +831,9 @@ async def list_issues(
             - ISSUE_STATUS_MONITORING
             - ISSUE_STATUS_MERGED
         schema_names: Optional list of schema names to filter issues by
+        assignee_ids: Optional list of integer user IDs to filter issues by assignee.
+            To filter by the current user ("assigned to me"), call get_current_user
+            first and use the returned 'id'.
         page_size: Optional number of issues to request from API per page (default: 20)
         page_cursor: Cursor for pagination
         compact: If True (default), returns only minimal fields (id, name, status, table, schema).
@@ -836,11 +861,14 @@ async def list_issues(
         debug_print(f"Filtering by statuses: {statuses}")
     if schema_names:
         debug_print(f"Filtering by schema names: {schema_names}")
+    if assignee_ids:
+        debug_print(f"Filtering by assignee IDs: {assignee_ids}")
 
     result = await client.fetch_issues(
         workspace_id=workspace_id,
         currentStatus=statuses,
         schemaNames=schema_names,
+        assignee_ids=assignee_ids,
         page_size=page_size if page_size else 20,
         page_cursor=page_cursor,
         include_full_history=False,

--- a/tests/fixtures/mcp_messages.json
+++ b/tests/fixtures/mcp_messages.json
@@ -29,6 +29,7 @@
     },
     "expected_tools": [
       "get_health_status",
+      "get_current_user",
       "list_issues",
       "get_issue",
       "search_issues",


### PR DESCRIPTION
## Summary

Adds the ability to answer **"find Bigeye issues assigned to me"** — previously `list_issues` had no assignee filter, so the MCP server couldn't do this at all.

The `POST /api/v1/issues/fetch` endpoint already supports an `assigneeIds` filter (proto field `repeated int32 assignee_ids = 30`); the client just never sent it. Assignee IDs are integers, so to resolve "me" we also expose the current user via the `/auth` endpoint (`UserAuth.id`).

## Changes

- **`bigeye_api.py`**
  - `fetch_current_user()` — `GET /auth`, returns the `UserAuth` payload (integer `id`, `email`, `name`, `companyId`, `workspaces`).
  - `fetch_issues()` — new `assignee_ids` param, sent as `assigneeIds` in the payload.
  - Surface the assignee's integer `id` (`assigneeId`) in compact + standard issue output, so filtering is verifiable and IDs are discoverable.
- **`server.py`**
  - New `get_current_user` MCP tool (trims the `/auth` response to the useful fields).
  - `list_issues` — new `assignee_ids` param. Both docstrings instruct the model to chain `get_current_user` → `list_issues(assignee_ids=[id])`.
- **Docs/tests** — README and the expected-tools test fixture updated.

## Verified locally

`get_current_user` returns the current user:

- Name: Tyler Jones
- Email: tyler@bigeye.com
- ID: 341
- Company ID: 111
- Workspaces (Admin on all): Bigeye default (4), AI Trust Hub Demo (341), Bigeye MCP server (308), Clean Test Env (288), Design (208), dbt test test (315), and several others

Then "Can you get issues assigned to me?" → chained `get_current_user` → `list_issues(assignee_ids=[341])` and returned **63 issues assigned to the user**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)