### PR TITLE
feat: Datadog usage telemetry, trace propagation, and MCP User-Agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ BIGEYE_API_KEY=your_api_key_here
 BIGEYE_BASE_URL=https://app.bigeye.com
 BIGEYE_WORKSPACE_ID=your_workspace_id_here
 BIGEYE_DEBUG=false
+# Anonymous usage telemetry (opt-out). Set to false to disable.
+BIGEYE_TELEMETRY=true

--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,3 @@ BIGEYE_API_KEY=your_api_key_here
 BIGEYE_BASE_URL=https://app.bigeye.com
 BIGEYE_WORKSPACE_ID=your_workspace_id_here
 BIGEYE_DEBUG=false
-# Anonymous usage telemetry (opt-out). Set to false to disable.
-BIGEYE_TELEMETRY=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 ## Configuration
 
 - Environment variables: `BIGEYE_API_KEY`, `BIGEYE_BASE_URL`, `BIGEYE_WORKSPACE_ID`
+- Optional env vars: `BIGEYE_DEBUG` (verbose logging), `BIGEYE_TELEMETRY` (anonymous usage telemetry, opt-out — set `false` to disable)
+- Telemetry ships metadata-only tool-call events to Bigeye's Datadog via a committed public Datadog client token (`telemetry.py`). No build-arg or per-customer setup needed.
 - Docker image must be tagged with both names: `bigeye-mcp-server:latest` and `bigeye-mcp-ephemeral:latest`
 
 ## Workflow Guidelines

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ telemetry does not affect functionality.
 > is origin identification only (no analytics) and is independent of the
 > `BIGEYE_TELEMETRY` setting.
 
+When telemetry is enabled, each tool call also propagates a Datadog distributed
+trace context (`x-datadog-trace-id` / `-parent-id` / `-sampling-priority`) onto the
+Bigeye API requests it makes, so those requests join the backend's APM trace for
+that tool call. The MCP server submits no spans itself — the backend (which already
+runs the Datadog tracer) creates them. The same trace ID is attached to the usage
+log event (`dd.trace_id`) to correlate logs with traces. This is gated by
+`BIGEYE_TELEMETRY`; no trace headers are sent when telemetry is disabled.
+
 ## Container Modes
 
 ### Long-Lived Container (Recommended)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,35 @@ An MCP (Model Context Protocol) server that provides tools for interacting with 
 - **BIGEYE_BASE_URL** — Your Bigeye instance URL (e.g. `https://app.bigeye.com`)
 - **BIGEYE_WORKSPACE_ID** — Found in your Bigeye URL after `/w/` (e.g. `https://app.bigeye.com/w/123/` → `123`)
 
+### Optional Environment Variables
+
+- **BIGEYE_DEBUG** — Set to `true` for verbose debug logging (default: `false`)
+- **BIGEYE_TELEMETRY** — Set to `false` to disable anonymous usage telemetry (default: `true`). See [Telemetry & Privacy](#telemetry--privacy).
+
+## Telemetry & Privacy
+
+The server sends anonymous, **metadata-only** usage analytics to Bigeye so we can
+understand how the MCP server is used and prioritize improvements. It is **on by
+default** and can be turned off at any time by setting `BIGEYE_TELEMETRY=false`.
+
+**What is collected** (per tool call):
+
+- Tool name, duration, and success/error status (plus the error *type* on failure)
+- An anonymous, randomly-generated install ID
+- Your workspace ID, the server version, and the runtime (docker vs. desktop)
+
+**What is never collected:** tool arguments, response bodies, query results,
+credentials, or any of your data, schema, table, or column names.
+
+Telemetry is delivered directly to Bigeye's Datadog over HTTPS (no agent required)
+and failures are silent — telemetry never blocks or slows a tool call. Disabling
+telemetry does not affect functionality.
+
+> Note: requests to the Bigeye API are sent with a `bigeye-mcp-server/<version>`
+> User-Agent so the backend's access logs can identify MCP-originated traffic. This
+> is origin identification only (no analytics) and is independent of the
+> `BIGEYE_TELEMETRY` setting.
+
 ## Container Modes
 
 ### Long-Lived Container (Recommended)
@@ -76,6 +105,7 @@ A fresh container spins up for each Claude Desktop session and is removed when d
         "-e", "BIGEYE_BASE_URL=https://app.bigeye.com",
         "-e", "BIGEYE_WORKSPACE_ID=your_workspace_id_here",
         "-e", "BIGEYE_DEBUG=false",
+        "-e", "BIGEYE_TELEMETRY=true",
         "bigeye-mcp-server:latest"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -46,39 +46,13 @@ An MCP (Model Context Protocol) server that provides tools for interacting with 
 ### Optional Environment Variables
 
 - **BIGEYE_DEBUG** — Set to `true` for verbose debug logging (default: `false`)
-- **BIGEYE_TELEMETRY** — Set to `false` to disable anonymous usage telemetry (default: `true`). See [Telemetry & Privacy](#telemetry--privacy).
+- **BIGEYE_TELEMETRY** — Set to `false` to disable anonymous usage telemetry (default: `true`). See [Telemetry](#telemetry).
 
-## Telemetry & Privacy
+## Telemetry
 
-The server sends anonymous, **metadata-only** usage analytics to Bigeye so we can
-understand how the MCP server is used and prioritize improvements. It is **on by
-default** and can be turned off at any time by setting `BIGEYE_TELEMETRY=false`.
-
-**What is collected** (per tool call):
-
-- Tool name, duration, and success/error status (plus the error *type* on failure)
-- An anonymous, randomly-generated install ID
-- Your workspace ID, the server version, and the runtime (docker vs. desktop)
-
-**What is never collected:** tool arguments, response bodies, query results,
-credentials, or any of your data, schema, table, or column names.
-
-Telemetry is delivered directly to Bigeye's Datadog over HTTPS (no agent required)
-and failures are silent — telemetry never blocks or slows a tool call. Disabling
-telemetry does not affect functionality.
-
-> Note: requests to the Bigeye API are sent with a `bigeye-mcp-server/<version>`
-> User-Agent so the backend's access logs can identify MCP-originated traffic. This
-> is origin identification only (no analytics) and is independent of the
-> `BIGEYE_TELEMETRY` setting.
-
-When telemetry is enabled, each tool call also propagates a Datadog distributed
-trace context (`x-datadog-trace-id` / `-parent-id` / `-sampling-priority`) onto the
-Bigeye API requests it makes, so those requests join the backend's APM trace for
-that tool call. The MCP server submits no spans itself — the backend (which already
-runs the Datadog tracer) creates them. The same trace ID is attached to the usage
-log event (`dd.trace_id`) to correlate logs with traces. This is gated by
-`BIGEYE_TELEMETRY`; no trace headers are sent when telemetry is disabled.
+To help us improve the server, anonymous usage analytics (tool name, duration,
+success/error) are sent to Bigeye. No arguments, results, or data are ever
+collected. Set `BIGEYE_TELEMETRY=false` to turn it off.
 
 ## Container Modes
 
@@ -113,7 +87,6 @@ A fresh container spins up for each Claude Desktop session and is removed when d
         "-e", "BIGEYE_BASE_URL=https://app.bigeye.com",
         "-e", "BIGEYE_WORKSPACE_ID=your_workspace_id_here",
         "-e", "BIGEYE_DEBUG=false",
-        "-e", "BIGEYE_TELEMETRY=true",
         "bigeye-mcp-server:latest"
       ]
     }

--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -8,7 +8,7 @@ import httpx
 import sys
 from typing import Dict, Any, Optional, List
 
-from telemetry import SERVER_VERSION
+from telemetry import SERVER_VERSION, trace_propagation_headers
 
 class BigeyeAPIClient:
     """Client for interacting with the Bigeye API."""
@@ -60,6 +60,11 @@ class BigeyeAPIClient:
         # Bigeye backend's existing access logs with no server-side changes. Always
         # sent (not gated by telemetry) -- it's origin identification, no analytics.
         headers["User-Agent"] = f"bigeye-mcp-server/{SERVER_VERSION}"
+
+        # Propagate the current tool call's Datadog trace context so this request
+        # joins the backend's APM trace (backend already runs ddtrace). Returns {}
+        # outside an instrumented tool call or when telemetry is disabled.
+        headers.update(trace_propagation_headers())
 
         # Verbose logging for ALL requests
         print(f"\n[BIGEYE API VERBOSE] === REQUEST DETAILS ===", file=sys.stderr)

--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -8,6 +8,8 @@ import httpx
 import sys
 from typing import Dict, Any, Optional, List
 
+from telemetry import SERVER_VERSION
+
 class BigeyeAPIClient:
     """Client for interacting with the Bigeye API."""
     
@@ -53,7 +55,12 @@ class BigeyeAPIClient:
         # Add workspace_id as a header if configured
         if self.workspace_id:
             headers["x-bigeye-workspace-id"] = str(self.workspace_id)
-        
+
+        # Identify MCP-originated traffic via the User-Agent so it shows up in the
+        # Bigeye backend's existing access logs with no server-side changes. Always
+        # sent (not gated by telemetry) -- it's origin identification, no analytics.
+        headers["User-Agent"] = f"bigeye-mcp-server/{SERVER_VERSION}"
+
         # Verbose logging for ALL requests
         print(f"\n[BIGEYE API VERBOSE] === REQUEST DETAILS ===", file=sys.stderr)
         print(f"[BIGEYE API VERBOSE] Method: {method}", file=sys.stderr)

--- a/config.py
+++ b/config.py
@@ -16,7 +16,9 @@ DEFAULT_CONFIG = {
     "api_url": "https://app.bigeye.com",
     "api_key": None,
     "workspace_id": None,
-    "debug": False
+    "debug": False,
+    "telemetry_enabled": True,
+    "telemetry_site": "datadoghq.com",
 }
 
 # Known typos/aliases -> correct variable name
@@ -53,12 +55,14 @@ def _print_startup_banner(cfg: dict) -> None:
     ws_id = cfg.get("workspace_id")
     ws_display = str(ws_id) if ws_id is not None else "NOT SET"
     debug_display = str(cfg.get("debug", False)).lower()
+    telemetry_display = "enabled" if cfg.get("telemetry_enabled", True) else "disabled"
 
     print("[BIGEYE MCP] Configuration Status:", file=sys.stderr)
     print(f"  BIGEYE_API_KEY:      {api_key_display}", file=sys.stderr)
     print(f"  BIGEYE_BASE_URL:     {base_url}", file=sys.stderr)
     print(f"  BIGEYE_WORKSPACE_ID: {ws_display}", file=sys.stderr)
     print(f"  BIGEYE_DEBUG:        {debug_display}", file=sys.stderr)
+    print(f"  BIGEYE_TELEMETRY:    {telemetry_display}", file=sys.stderr)
 
 
 def _check_typos() -> None:
@@ -136,7 +140,14 @@ config = {
     "workspace_id": None,  # Will be set below with proper error handling
 
     # Debug mode (env var only)
-    "debug": os.environ.get("BIGEYE_DEBUG", "").lower() in ["true", "1", "yes"]
+    "debug": os.environ.get("BIGEYE_DEBUG", "").lower() in ["true", "1", "yes"],
+
+    # Anonymous usage telemetry to Bigeye's Datadog. Opt-out: ON unless explicitly
+    # disabled with BIGEYE_TELEMETRY=false. Positive-sense flag (no double negative).
+    "telemetry_enabled": os.environ.get("BIGEYE_TELEMETRY", "true").lower() in ["true", "1", "yes"],
+
+    # Datadog site to ship telemetry to (override for non-US1 orgs / testing).
+    "telemetry_site": os.environ.get("BIGEYE_TELEMETRY_SITE", DEFAULT_CONFIG["telemetry_site"]),
 }
 
 # Handle workspace_id conversion with proper error handling

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,10 @@ services:
       
       # Optional: Debug mode
       - BIGEYE_DEBUG=${BIGEYE_DEBUG:-false}
-      
+
+      # Optional: Anonymous usage telemetry (opt-out). Set to false to disable.
+      - BIGEYE_TELEMETRY=${BIGEYE_TELEMETRY:-true}
+
       # Python environment
       - PYTHONUNBUFFERED=1
       - PYTHONDONTWRITEBYTECODE=1

--- a/server.py
+++ b/server.py
@@ -20,6 +20,7 @@ from auth import BigeyeAuthClient
 from bigeye_api import BigeyeAPIClient
 from config import config
 from lineage_tracker import AgentLineageTracker
+from telemetry import init_telemetry, instrument_tools
 
 # ---------------------------------------------------------------------------
 # Metric type → column type applicability
@@ -308,6 +309,13 @@ def debug_print(message: str):
     """Print debug messages to stderr"""
     if config["debug"] or os.environ.get("BIGEYE_DEBUG", "false").lower() in ["true", "1", "yes"]:
         print(f"[BIGEYE MCP DEBUG] {message}", file=sys.stderr)
+
+
+# Initialize usage telemetry and instrument every tool. This must run before any
+# @mcp.tool() decorator below so the wrapper is applied at registration time.
+_telemetry = init_telemetry(config)
+instrument_tools(mcp, _telemetry)
+debug_print(f"Telemetry {'enabled' if _telemetry.enabled else 'disabled'}")
 
 
 async def _resolve_table(

--- a/telemetry.py
+++ b/telemetry.py
@@ -253,7 +253,9 @@ def init_telemetry(config: dict) -> TelemetryClient:
         enabled=enabled,
         client_token=client_token,
         site=site,
-        install_id=get_or_create_install_id(),
+        # Only generate/persist a tracking ID when telemetry is enabled, so
+        # opting out (BIGEYE_TELEMETRY=false) writes nothing to disk.
+        install_id=get_or_create_install_id() if enabled else "",
         workspace_id=config.get("workspace_id"),
         intake_url=intake_url,
     )

--- a/telemetry.py
+++ b/telemetry.py
@@ -19,6 +19,7 @@ Design notes:
 """
 
 import atexit
+import contextvars
 import functools
 import inspect
 import os
@@ -28,7 +29,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 import httpx
 
@@ -52,6 +53,57 @@ _BROWSER_INTAKE_HOSTS = {
 
 _SOURCE = "bigeye-mcp-server"
 _SERVICE = "bigeye-mcp-server"
+
+# Distributed-tracing propagation. Per tool call we mint a Datadog trace context
+# and inject it onto the HTTP requests the tool makes to the Bigeye API, so those
+# requests join the backend's existing APM trace (the backend already runs ddtrace).
+# We never submit spans ourselves -- the backend creates them under this trace id.
+#
+# USER_KEEP (2): MCP traffic is low-volume and human-driven, so we force retention
+# to make these traces reliably findable. Revisit if volume/cost grows.
+_TRACE_SAMPLING_PRIORITY = "2"
+_trace_ctx: "contextvars.ContextVar[Optional[Tuple[int, int]]]" = contextvars.ContextVar(
+    "bigeye_trace_ctx", default=None
+)
+
+
+def _gen_trace_id() -> int:
+    """Random non-zero 64-bit id (Datadog trace/span id format)."""
+    return int.from_bytes(os.urandom(8), "big") or 1
+
+
+def start_trace_context() -> Any:
+    """Begin a trace context for the current tool call; returns a reset token."""
+    return _trace_ctx.set((_gen_trace_id(), _gen_trace_id()))
+
+
+def reset_trace_context(token: Any) -> None:
+    try:
+        _trace_ctx.reset(token)
+    except Exception:
+        pass
+
+
+def current_trace_context() -> Optional[Tuple[int, int]]:
+    return _trace_ctx.get()
+
+
+def trace_propagation_headers() -> dict:
+    """Datadog distributed-tracing headers for the active tool call, or {} if none.
+
+    Safe to call from anywhere: returns {} when no tool-call context is active
+    (e.g. telemetry disabled, or a request made outside an instrumented tool).
+    """
+    ctx = _trace_ctx.get()
+    if not ctx:
+        return {}
+    trace_id, span_id = ctx
+    return {
+        "x-datadog-trace-id": str(trace_id),
+        "x-datadog-parent-id": str(span_id),
+        "x-datadog-sampling-priority": _TRACE_SAMPLING_PRIORITY,
+    }
+
 
 # Worker tuning.
 _QUEUE_MAXSIZE = 1000
@@ -141,6 +193,8 @@ class TelemetryClient:
         duration_ms: float,
         status: str,
         error_type: Optional[str],
+        trace_id: Optional[int] = None,
+        span_id: Optional[int] = None,
     ) -> None:
         """Enqueue a tool-call event. Non-blocking; dropped if the queue is full."""
         if not self.enabled:
@@ -159,6 +213,10 @@ class TelemetryClient:
             "server_version": SERVER_VERSION,
             "runtime": self.runtime,
         }
+        if trace_id is not None:
+            # Correlate this log to the backend APM trace for the same tool call.
+            event["dd.trace_id"] = str(trace_id)
+            event["dd.span_id"] = str(span_id)
         try:
             self._queue.put_nowait(event)
         except queue.Full:
@@ -264,11 +322,19 @@ def init_telemetry(config: dict) -> TelemetryClient:
 
 
 def _wrap(fn, telemetry: TelemetryClient):
-    """Wrap a tool function so each invocation records a telemetry event."""
+    """Wrap a tool function so each invocation records a telemetry event and runs
+    under a trace context that gets propagated to the Bigeye API requests it makes."""
 
     def _record(start: float, status: str, error_type: Optional[str]) -> None:
+        ctx = current_trace_context()
+        trace_id, span_id = ctx if ctx else (None, None)
         telemetry.record_tool_call(
-            fn.__name__, (time.perf_counter() - start) * 1000, status, error_type
+            fn.__name__,
+            (time.perf_counter() - start) * 1000,
+            status,
+            error_type,
+            trace_id,
+            span_id,
         )
 
     if inspect.iscoroutinefunction(fn):
@@ -276,6 +342,7 @@ def _wrap(fn, telemetry: TelemetryClient):
         @functools.wraps(fn)
         async def traced(*args, **kwargs):
             start = time.perf_counter()
+            token = start_trace_context()
             status, error_type = "ok", None
             try:
                 result = await fn(*args, **kwargs)
@@ -287,12 +354,14 @@ def _wrap(fn, telemetry: TelemetryClient):
                 raise
             finally:
                 _record(start, status, error_type)
+                reset_trace_context(token)
 
         return traced
 
     @functools.wraps(fn)
     def traced(*args, **kwargs):
         start = time.perf_counter()
+        token = start_trace_context()
         status, error_type = "ok", None
         try:
             result = fn(*args, **kwargs)
@@ -304,6 +373,7 @@ def _wrap(fn, telemetry: TelemetryClient):
             raise
         finally:
             _record(start, status, error_type)
+            reset_trace_context(token)
 
     return traced
 

--- a/telemetry.py
+++ b/telemetry.py
@@ -1,0 +1,333 @@
+"""
+Telemetry for the Bigeye MCP Server.
+
+Reports anonymous, metadata-only usage analytics (which tool was called, how long
+it took, success/error) to Bigeye's Datadog org so we can understand how the MCP
+server is used in the field.
+
+Design notes:
+- Opt-out. Controlled by the BIGEYE_TELEMETRY env var (default ON). See config.py.
+- No Datadog Agent required. Events are POSTed directly to Datadog's browser-logs
+  intake endpoint, authenticating with a public Datadog *client token* (safe to
+  commit / distribute -- it can only submit logs, never read or manage the org).
+- Never blocks or breaks a tool call. Events are enqueued (non-blocking, dropped
+  if the queue is full) and shipped from a background daemon thread. Every network
+  operation is wrapped in a catch-all; telemetry failures are silent.
+- Metadata only. We capture the tool name, duration, status, and error *type* --
+  never tool arguments or response bodies (those carry customer schema/table/column
+  names and secrets).
+"""
+
+import atexit
+import functools
+import inspect
+import os
+import queue
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+
+# Mirror pyproject.toml version.
+SERVER_VERSION = "0.1.0"
+
+# Public Datadog client token, committed on purpose. Client tokens are designed to
+# be embedded in publicly-distributed code: they can only *submit* logs/RUM and
+# cannot read data or manage the org. Override via BIGEYE_TELEMETRY_CLIENT_TOKEN.
+DEFAULT_TELEMETRY_CLIENT_TOKEN = "pub9216acb353e273f29e84a7bdcbd3b875"
+
+# Maps a Datadog site to its browser-logs intake host.
+_BROWSER_INTAKE_HOSTS = {
+    "datadoghq.com": "browser-intake-datadoghq.com",
+    "us3.datadoghq.com": "browser-intake-us3-datadoghq.com",
+    "us5.datadoghq.com": "browser-intake-us5-datadoghq.com",
+    "datadoghq.eu": "browser-intake-datadoghq.eu",
+    "ap1.datadoghq.com": "browser-intake-ap1-datadoghq.com",
+    "ddog-gov.com": "browser-intake-ddog-gov.com",
+}
+
+_SOURCE = "bigeye-mcp-server"
+_SERVICE = "bigeye-mcp-server"
+
+# Worker tuning.
+_QUEUE_MAXSIZE = 1000
+_BATCH_MAX = 50
+_FLUSH_INTERVAL_SECS = 5.0
+_HTTP_TIMEOUT_SECS = 5.0
+_SHUTDOWN_JOIN_SECS = 3.0
+
+_STOP = object()  # sentinel pushed onto the queue to stop the worker
+
+
+def _detect_runtime() -> str:
+    """Best-effort runtime detection (docker vs. local/desktop)."""
+    if Path("/.dockerenv").exists() or os.environ.get("container"):
+        return "docker"
+    return "claude-desktop"
+
+
+def get_or_create_install_id() -> str:
+    """Return a stable anonymous install ID.
+
+    Persisted next to the credentials (Path.home()/.bigeye-mcp), which is
+    volume-mounted in docker-compose, so it survives restarts. Falls back to an
+    ephemeral in-memory ID if the file can't be read/written.
+    """
+    try:
+        path = Path.home() / ".bigeye-mcp" / "install_id"
+        if path.exists():
+            existing = path.read_text().strip()
+            if existing:
+                return existing
+        path.parent.mkdir(parents=True, exist_ok=True)
+        new_id = uuid.uuid4().hex
+        path.write_text(new_id)
+        return new_id
+    except Exception:
+        return uuid.uuid4().hex
+
+
+def _intake_url(site: str, client_token: str, explicit_url: Optional[str]) -> str:
+    """Build the browser-logs intake URL (token passed as a query param)."""
+    if explicit_url:
+        base = explicit_url
+    else:
+        host = _BROWSER_INTAKE_HOSTS.get(site, f"browser-intake-{site}")
+        base = f"https://{host}/api/v2/logs"
+    sep = "&" if "?" in base else "?"
+    return (
+        f"{base}{sep}dd-api-key={client_token}"
+        f"&ddsource={_SOURCE}&dd-evp-origin=bigeye-mcp"
+    )
+
+
+class TelemetryClient:
+    """Buffers tool-call events and ships them to Datadog from a daemon thread."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        client_token: Optional[str],
+        site: str,
+        install_id: str,
+        workspace_id: Optional[int],
+        intake_url: Optional[str] = None,
+    ):
+        self.enabled = bool(enabled and client_token)
+        self.install_id = install_id
+        self.workspace_id = workspace_id
+        self.runtime = _detect_runtime()
+        self._url = _intake_url(site, client_token, intake_url) if self.enabled else None
+        self._queue: "queue.Queue[Any]" = queue.Queue(maxsize=_QUEUE_MAXSIZE)
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if not self.enabled or self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._worker, name="bigeye-telemetry", daemon=True
+        )
+        self._thread.start()
+        atexit.register(self._shutdown)
+
+    def record_tool_call(
+        self,
+        name: str,
+        duration_ms: float,
+        status: str,
+        error_type: Optional[str],
+    ) -> None:
+        """Enqueue a tool-call event. Non-blocking; dropped if the queue is full."""
+        if not self.enabled:
+            return
+        event = {
+            "ddsource": _SOURCE,
+            "service": _SERVICE,
+            "ddtags": f"version:{SERVER_VERSION},tool:{name},status:{status}",
+            "message": "mcp.tool.call",
+            "tool": name,
+            "duration_ms": round(duration_ms, 2),
+            "status": status,
+            "error_type": error_type,
+            "install_id": self.install_id,
+            "workspace_id": self.workspace_id,
+            "server_version": SERVER_VERSION,
+            "runtime": self.runtime,
+        }
+        try:
+            self._queue.put_nowait(event)
+        except queue.Full:
+            pass
+
+    # -- background worker ---------------------------------------------------
+
+    def _worker(self) -> None:
+        client = httpx.Client(timeout=_HTTP_TIMEOUT_SECS)
+        try:
+            while True:
+                batch, stop = self._drain()
+                if batch:
+                    self._send(client, batch)
+                if stop:
+                    return
+        finally:
+            try:
+                client.close()
+            except Exception:
+                pass
+
+    def _drain(self):
+        """Block for the next item, then opportunistically pull more (up to a
+        batch), returning (events, stop_requested)."""
+        batch = []
+        stop = False
+        try:
+            first = self._queue.get(timeout=_FLUSH_INTERVAL_SECS)
+            if first is _STOP:
+                return batch, True
+            batch.append(first)
+        except queue.Empty:
+            return batch, False
+        while len(batch) < _BATCH_MAX:
+            try:
+                item = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            if item is _STOP:
+                stop = True
+                break
+            batch.append(item)
+        return batch, stop
+
+    def _send(self, client: httpx.Client, batch) -> None:
+        try:
+            client.post(
+                self._url,
+                json=batch,
+                headers={"Content-Type": "application/json"},
+            )
+        except Exception:
+            # Telemetry must never surface errors to the caller.
+            pass
+
+    def _shutdown(self) -> None:
+        if self._thread is None:
+            return
+        try:
+            self._queue.put_nowait(_STOP)
+        except queue.Full:
+            pass
+        self._thread.join(timeout=_SHUTDOWN_JOIN_SECS)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton + instrumentation
+# ---------------------------------------------------------------------------
+
+_client: Optional[TelemetryClient] = None
+
+
+def init_telemetry(config: dict) -> TelemetryClient:
+    """Create (once) and start the telemetry client from the loaded config."""
+    global _client
+    if _client is not None:
+        return _client
+
+    enabled = config.get("telemetry_enabled", True)
+    client_token = (
+        os.environ.get("BIGEYE_TELEMETRY_CLIENT_TOKEN")
+        or config.get("telemetry_client_token")
+        or DEFAULT_TELEMETRY_CLIENT_TOKEN
+    )
+    site = config.get("telemetry_site") or "datadoghq.com"
+    intake_url = os.environ.get("BIGEYE_TELEMETRY_INTAKE_URL") or config.get(
+        "telemetry_intake_url"
+    )
+
+    _client = TelemetryClient(
+        enabled=enabled,
+        client_token=client_token,
+        site=site,
+        install_id=get_or_create_install_id(),
+        workspace_id=config.get("workspace_id"),
+        intake_url=intake_url,
+    )
+    _client.start()
+    return _client
+
+
+def _wrap(fn, telemetry: TelemetryClient):
+    """Wrap a tool function so each invocation records a telemetry event."""
+
+    def _record(start: float, status: str, error_type: Optional[str]) -> None:
+        telemetry.record_tool_call(
+            fn.__name__, (time.perf_counter() - start) * 1000, status, error_type
+        )
+
+    if inspect.iscoroutinefunction(fn):
+
+        @functools.wraps(fn)
+        async def traced(*args, **kwargs):
+            start = time.perf_counter()
+            status, error_type = "ok", None
+            try:
+                result = await fn(*args, **kwargs)
+                if isinstance(result, dict) and result.get("error"):
+                    status, error_type = "error", "tool_error"
+                return result
+            except Exception as e:
+                status, error_type = "error", type(e).__name__
+                raise
+            finally:
+                _record(start, status, error_type)
+
+        return traced
+
+    @functools.wraps(fn)
+    def traced(*args, **kwargs):
+        start = time.perf_counter()
+        status, error_type = "ok", None
+        try:
+            result = fn(*args, **kwargs)
+            if isinstance(result, dict) and result.get("error"):
+                status, error_type = "error", "tool_error"
+            return result
+        except Exception as e:
+            status, error_type = "error", type(e).__name__
+            raise
+        finally:
+            _record(start, status, error_type)
+
+    return traced
+
+
+def instrument_tools(mcp, telemetry: TelemetryClient) -> None:
+    """Monkeypatch ``mcp.tool`` so every subsequently-registered tool is timed.
+
+    Must be called immediately after ``FastMCP(...)`` and before any ``@mcp.tool()``
+    decorators run. No-op when telemetry is disabled.
+    """
+    if not telemetry.enabled:
+        return
+
+    original_tool = mcp.tool
+
+    def traced_tool(*d_args, **d_kwargs):
+        # Support the bare ``@mcp.tool`` form (function passed directly).
+        if len(d_args) == 1 and not d_kwargs and callable(d_args[0]):
+            fn = d_args[0]
+            return original_tool(_wrap(fn, telemetry))
+
+        decorator = original_tool(*d_args, **d_kwargs)
+
+        def register(fn):
+            return decorator(_wrap(fn, telemetry))
+
+        return register
+
+    mcp.tool = traced_tool


### PR DESCRIPTION
## What & why

Adds **opt-out, metadata-only usage telemetry** so we can see how the Bigeye MCP server is used in the field — which tools get called, how often, latency, error rates — reported into **Bigeye's own Datadog org**. The server is distributed as a Docker image users run themselves, so there's no Datadog Agent available; everything here is agentless and works with zero per-customer setup.

Here is a sample log and trace with this change:

https://app.datadoghq.com/logs/livetail?query=service%3Abigeye-mcp-server&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=driveline&stream_sort=desc&viz=stream&from_ts=1781014438444&to_ts=1781015338444&live=false

<img width="967" height="623" alt="image" src="https://github.com/user-attachments/assets/3e3c1c01-b6f6-4138-879a-66ef26c966e1" />
<img width="1436" height="1161" alt="image" src="https://github.com/user-attachments/assets/431c7f4d-449d-4b5f-b6e3-2be96fd67e38" />

Fixes: ENG-14462


## What it does

**Usage telemetry → Datadog (`telemetry.py`)**
- A background daemon thread + bounded queue ships one event per tool call over HTTPS to Datadog's **browser-logs intake**, authenticating with a committed **public Datadog client token** (`pub…`) — client tokens are built to be embedded in distributed code and can only submit logs, never read or manage the org.
- Reuses the existing `httpx` dependency — no new deps, no `ddtrace`, no Agent.
- Every tool is instrumented at once by patching `mcp.tool` a single time (no per-tool edits); `functools.wraps` preserves each tool's signature for FastMCP schema generation. Tools added on `master` are covered automatically.
- **Fail-silent**: never blocks or breaks a tool call; all network ops are wrapped in a catch-all with a bounded `atexit` flush.
- **Collected:** tool name, duration, status + error *type*, anonymous install ID, workspace ID, server version, runtime. **Never:** arguments, responses, results, credentials, or schema/table/column names.
- **Opt-out:** `BIGEYE_TELEMETRY=false` disables it (positive-sense flag, default on). When disabled, no install ID is generated or written to disk.

**Trace-context propagation (`telemetry.py` + `bigeye_api.py`)**
- Each tool call mints a Datadog trace context and injects `x-datadog-trace-id` / `-parent-id` / `-sampling-priority` onto the Bigeye API requests it makes, so those requests join the backend's existing APM trace (the backend already runs ddtrace). The MCP server submits no spans — the backend creates them under the propagated ID.
- All API calls within one tool call share the trace ID; the same ID is stamped on the usage log (`dd.trace_id`) for log↔trace correlation. Gated by `BIGEYE_TELEMETRY`.
- Sampling priority is `USER_KEEP` (2) since MCP traffic is low-volume and human-driven. Isolated in its own commit (`ae8c862`) so it can be reverted independently if the backend's edge trace-merge behavior isn't what we want.

**Server-side identification (`bigeye_api.py`)**
- All Bigeye API requests send a `bigeye-mcp-server/<version>` **User-Agent**, so existing backend access logs distinguish MCP traffic with no server-side changes. Independent of the telemetry setting.

## Files
- `telemetry.py` (new) — telemetry client, install-ID persistence, trace context, tool instrumentation
- `config.py`, `server.py` — load config, init + instrument at startup
- `bigeye_api.py` — User-Agent + trace-header propagation
- `README.md` (short Telemetry section), `CLAUDE.md`, `docker-compose.yml`

## Verification
Tested against a mock intake/echo server:
- Events captured with correct `status` / `duration_ms`; dict-`error` → `tool_error`, raised exc → exception class name; asserted **no keys/values leaked** beyond the metadata allowlist.
- `User-Agent: bigeye-mcp-server/<version>` lands on API requests.
- Trace propagation: requests inside a tool call share one trace ID at priority 2; the log's `dd.trace_id` matches the propagated header; nothing propagated outside a tool call.
- Disabled path (`BIGEYE_TELEMETRY=false`): no thread, no instrumentation, no install ID written, empty trace headers. Unset ⇒ enabled.
- Fail-safe: unreachable intake — tool returns normally (~18ms), shutdown bounded.

## Open item to confirm when testing
At the public edge, `datawatch` may **restart** an inbound trace (observed `terminated_context` span-links on synthetics traffic) rather than continue it. If it merges, the `service:bigeye-mcp-server` log's `dd.trace_id` opens the exact backend trace; if it restarts, the server trace gets a different ID linked via span-link. Easy to revert the propagation commit or switch propagation style based on what we see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
