### PR TITLE
feat: re-implement catalog search tools on /api/v2/search (ENG-12423)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 
 ## API Quirks
 
-- The `POST /api/v1/search` endpoint is broken — it ignores `searchString` and filter parameters, returning all issues in a fixed order. Only `limit` works. Catalog search tools are temporarily removed pending improvements (see ONE-12139).
+- The `POST /api/v1/search` endpoint is broken — it ignores `searchString` and filter parameters, returning all issues in a fixed order. Only `limit` works. Do not use it. Catalog search (`search_schemas`/`search_tables`/`search_columns`) is implemented on `POST /api/v2/search`, which honors the `search` query string, `types` filter, and `limit`. The v2 body uses protobuf-JSON: `{"search": "...", "types": [{"dataNodeType": "DATA_NODE_TYPE_TABLE"}], "limit": N}` — workspace comes from the `x-bigeye-workspace-id` header, not the body.
 - Workspace IDs must be integers, not strings
 - Some endpoints use camelCase, others use snake_case
 - Search endpoints require exact matches with underscores (e.g. `sales_dashboard` not `sales dashboard`)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ To connect to multiple Bigeye instances (e.g. demo and production), create separ
 - **`list_data_classes`** — List data classification categories (e.g., "Email Address", "US SSN") with sensitivity levels
 - **`get_scan_findings`** — Get column-level classification scan results showing where sensitive data was detected
 
+### Data Catalog
+
+- **`search_schemas`** — Search the data catalog for schemas by name (returns ids + warehouse)
+- **`search_tables`** — Search the data catalog for tables by name (returns ids, schema + warehouse)
+- **`search_columns`** — Search the data catalog for columns by name (returns ids, type + parent table)
+
 ### Data Lineage
 
 - **`get_lineage_graph`** — Get the full lineage graph (upstream/downstream/both) from a starting node

--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -1526,7 +1526,42 @@ class BigeyeAPIClient:
             method="GET",
             params=params
         )
-        
+
+    async def catalog_search(
+        self,
+        search: str,
+        data_node_types: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Catalog/global search via POST /api/v2/search.
+
+        Unlike the broken /api/v1/search, this endpoint honors the query string,
+        type filters, and limit. The workspace is taken from the
+        x-bigeye-workspace-id header (set by make_request), not the body.
+
+        Args:
+            search: The query string to search for.
+            data_node_types: Optional list of DataNodeType enum names to filter by
+                (e.g. ["DATA_NODE_TYPE_TABLE"]).
+            limit: Optional maximum number of results to return.
+
+        Returns:
+            The raw SearchResponse: {"results": [{<oneOfKey>: {...}}, ...]}.
+        """
+        payload: Dict[str, Any] = {"search": search}
+        if data_node_types:
+            payload["types"] = [{"dataNodeType": t} for t in data_node_types]
+        if limit is not None:
+            payload["limit"] = limit
+
+        print(f"[BIGEYE API DEBUG] Catalog search payload: {payload}", file=sys.stderr)
+
+        return await self.make_request(
+            "/api/v2/search",
+            method="POST",
+            json_data=payload,
+        )
+
     async def get_table_level_metric_names(self) -> Dict[str, Any]:
         """Get the list of table-level metric names from the Bigeye API.
 

--- a/server.py
+++ b/server.py
@@ -970,6 +970,148 @@ async def search_issues(
 
     return result
 
+# Catalog search tools. These use the v2 global-search endpoint
+# (POST /api/v2/search via client.catalog_search) which honors the query string,
+# type filters, and limit. Note: the internal resolve_table() helper and lineage
+# code still use the client's v1 search_tables/search_schemas/search_columns
+# methods (GET /api/v1/{tables,schemas,columns}) -- those are unchanged.
+@mcp.tool()
+async def search_schemas(
+    query: str,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """Search the Bigeye data catalog for schemas by name. Returns matching schemas with their internal IDs and warehouse context.
+
+    Args:
+        query: The schema name or partial name to search for (e.g. "sales", "public")
+        limit: Maximum number of results to return (default: 50)
+    """
+    client = get_api_client()
+    if not config.get('workspace_id'):
+        return {
+            'error': 'Workspace ID not configured',
+            'hint': 'Check your Claude Desktop configuration'
+        }
+
+    debug_print(f"Catalog schema search for: {query}")
+    response = await client.catalog_search(
+        search=query,
+        data_node_types=["DATA_NODE_TYPE_SCHEMA"],
+        limit=limit,
+    )
+    if response.get("error"):
+        return response
+
+    schemas = []
+    for result in response.get("results", []):
+        node = result.get("schemaNode")
+        if not node:
+            continue
+        schemas.append({
+            "id": node.get("id"),
+            "name": node.get("name"),
+            "warehouseId": node.get("warehouseId"),
+            "warehouseName": node.get("warehouseName"),
+        })
+
+    debug_print(f"Found {len(schemas)} schemas matching '{query}'")
+    return {"results": schemas, "count": len(schemas)}
+
+@mcp.tool()
+async def search_tables(
+    query: str,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """Search the Bigeye data catalog for tables by name. Returns matching tables with their internal IDs, schema, and warehouse context.
+
+    Args:
+        query: The table name or partial name to search for (e.g. "orders", "customer")
+        limit: Maximum number of results to return (default: 50)
+    """
+    client = get_api_client()
+    if not config.get('workspace_id'):
+        return {
+            'error': 'Workspace ID not configured',
+            'hint': 'Check your Claude Desktop configuration'
+        }
+
+    debug_print(f"Catalog table search for: {query}")
+    response = await client.catalog_search(
+        search=query,
+        data_node_types=["DATA_NODE_TYPE_TABLE"],
+        limit=limit,
+    )
+    if response.get("error"):
+        return response
+
+    tables = []
+    for result in response.get("results", []):
+        node = result.get("tableNode")
+        if not node:
+            continue
+        tables.append({
+            "id": node.get("id"),
+            "name": node.get("name"),
+            "schemaName": node.get("schemaName"),
+            "databaseName": node.get("databaseName"),
+            "warehouseId": node.get("warehouseId"),
+            "warehouseName": node.get("warehouseName"),
+        })
+
+    debug_print(f"Found {len(tables)} tables matching '{query}'")
+    return {"results": tables, "count": len(tables)}
+
+@mcp.tool()
+async def search_columns(
+    query: str,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """Search the Bigeye data catalog for columns by name. Returns matching columns with their internal IDs, data type, and the table/schema/warehouse they belong to.
+
+    Args:
+        query: The column name or partial name to search for (e.g. "email", "user_id")
+        limit: Maximum number of results to return (default: 50)
+    """
+    client = get_api_client()
+    if not config.get('workspace_id'):
+        return {
+            'error': 'Workspace ID not configured',
+            'hint': 'Check your Claude Desktop configuration'
+        }
+
+    debug_print(f"Catalog column search for: {query}")
+    response = await client.catalog_search(
+        search=query,
+        data_node_types=["DATA_NODE_TYPE_COLUMN"],
+        limit=limit,
+    )
+    if response.get("error"):
+        return response
+
+    columns = []
+    for result in response.get("results", []):
+        node = result.get("columnNode")
+        if not node:
+            continue
+        column = node.get("column") or {}
+        table = node.get("table") or {}
+        columns.append({
+            "column": {
+                "id": column.get("id"),
+                "name": column.get("name"),
+                "type": column.get("type"),
+            },
+            "table": {
+                "id": table.get("id"),
+                "name": table.get("name"),
+                "schemaName": table.get("schemaName"),
+                "warehouseName": table.get("warehouseName"),
+            },
+        })
+
+    debug_print(f"Found {len(columns)} columns matching '{query}'")
+    return {"results": columns, "count": len(columns)}
+
 @mcp.tool()
 async def list_related_issues(
     starting_issue_id: int

--- a/server.py
+++ b/server.py
@@ -982,8 +982,15 @@ async def search_schemas(
 ) -> Dict[str, Any]:
     """Search the Bigeye data catalog for schemas by name. Returns matching schemas with their internal IDs and warehouse context.
 
+    Schema names are in `database.schema` format when the warehouse has a
+    database layer (e.g. Snowflake: "ANALYTICS.PUBLIC"); for warehouses without a
+    database, the name is just the schema (e.g. "public"). Returned `name` values
+    follow the same convention.
+
     Args:
-        query: The schema name or partial name to search for (e.g. "sales", "public")
+        query: The schema name or partial name to search for. Include the database
+            prefix when applicable (e.g. "ANALYTICS.PUBLIC"), or search by just the
+            schema part (e.g. "public") for a broader match.
         limit: Maximum number of results to return (default: 50)
     """
     client = get_api_client()

--- a/server.py
+++ b/server.py
@@ -1031,6 +1031,10 @@ async def search_tables(
 ) -> Dict[str, Any]:
     """Search the Bigeye data catalog for tables by name. Returns matching tables with their internal IDs, schema, and warehouse context.
 
+    The returned `schemaName` is in `database.schema` format when the warehouse
+    has a database layer (e.g. Snowflake: "ANALYTICS.PUBLIC"); for warehouses
+    without a database, it is just the schema (e.g. "public").
+
     Args:
         query: The table name or partial name to search for (e.g. "orders", "customer")
         limit: Maximum number of results to return (default: 50)
@@ -1074,6 +1078,10 @@ async def search_columns(
     limit: int = 50,
 ) -> Dict[str, Any]:
     """Search the Bigeye data catalog for columns by name. Returns matching columns with their internal IDs, data type, and the table/schema/warehouse they belong to.
+
+    The returned `table.schemaName` is in `database.schema` format when the
+    warehouse has a database layer (e.g. Snowflake: "ANALYTICS.PUBLIC"); for
+    warehouses without a database, it is just the schema (e.g. "public").
 
     Args:
         query: The column name or partial name to search for (e.g. "email", "user_id")

--- a/server.py
+++ b/server.py
@@ -994,7 +994,7 @@ async def search_schemas(
         limit: Maximum number of results to return (default: 50)
     """
     client = get_api_client()
-    if not config.get('workspace_id'):
+    if not client.workspace_id:
         return {
             'error': 'Workspace ID not configured',
             'hint': 'Check your Claude Desktop configuration'
@@ -1040,7 +1040,7 @@ async def search_tables(
         limit: Maximum number of results to return (default: 50)
     """
     client = get_api_client()
-    if not config.get('workspace_id'):
+    if not client.workspace_id:
         return {
             'error': 'Workspace ID not configured',
             'hint': 'Check your Claude Desktop configuration'
@@ -1088,7 +1088,7 @@ async def search_columns(
         limit: Maximum number of results to return (default: 50)
     """
     client = get_api_client()
-    if not config.get('workspace_id'):
+    if not client.workspace_id:
         return {
             'error': 'Workspace ID not configured',
             'hint': 'Check your Claude Desktop configuration'


### PR DESCRIPTION
## Summary

Re-implements the catalog search MCP tools `search_schemas`, `search_tables`, and `search_columns` (removed in #6) against the **`POST /api/v2/search`** endpoint, per ENG-12423.

The old tools issued API calls that didn't match the contract (a non-existent `searchString` param; `POST /api/v1/search` was broken — it ignored filters and returned everything in a fixed order). The v2 search endpoint honors the `search` query string, `types` filter, and `limit`.

## Changes

- **`bigeye_api.py`** — new `catalog_search()` posting the protobuf-JSON `SearchRequest` (`{search, types, limit}`). Workspace is taken from the `x-bigeye-workspace-id` header (set by `make_request`), not the body. The existing v1 `search_schemas`/`search_tables`/`search_columns` helpers — still used by `resolve_table` and lineage code — are left untouched.
- **`server.py`** — three `@mcp.tool()`s that filter by `DataNodeType` and normalize the `schemaNode`/`tableNode`/`columnNode` results into clean `{results, count}` dicts:
  - `search_schemas` → id, name, warehouse
  - `search_tables` → id, name, schema, warehouse
  - `search_columns` → column (id/name/type) + parent table
- **`CLAUDE.md` / `README.md`** — document the v2 search contract and list the catalog tools.

The v2 contract (request/response shape, `DataNodeType` enum values, result node fields) was verified directly against Bigeye source (`SearchV2Resource.java`, `Datawatch.proto`, `getSearchV2.ts`).

## Verification

- [x] `python3 -m py_compile bigeye_api.py server.py` — clean
- [ ] Live round-trip against `/api/v2/search` with configured credentials (requires Docker/Claude Desktop env — not available in this workspace)
- [ ] Exercise the three tools in Claude Desktop
- [ ] Confirm no regression in `resolve_table`-dependent tools (v1 helpers unchanged)

Closes ENG-12423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
