### PR TITLE
fix: resolve workspace ID per-request so MCP gateway header works

### DIFF
--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -13,18 +13,36 @@ from telemetry import SERVER_VERSION, trace_propagation_headers
 class BigeyeAPIClient:
     """Client for interacting with the Bigeye API."""
     
-    def __init__(self, api_url: str = "https://staging.bigeye.com", api_key: Optional[str] = None, workspace_id: Optional[int] = None):
+    def __init__(self, api_url: str = "https://staging.bigeye.com", api_key: Optional[str] = None, workspace_id: Optional[int] = None, per_request: bool = False):
         """Initialize the Bigeye API client.
-        
+
         Args:
             api_url: The URL of the Bigeye API
             api_key: The API key for authentication
             workspace_id: The workspace ID to use for API requests
+            per_request: True when the client was built from per-request HTTP
+                credentials (headers); False for the env-configured global client.
+                Only affects the error message when no workspace ID is available.
         """
         self.api_url = api_url
         self.api_key = api_key
         self.workspace_id = workspace_id
-    
+        self.per_request = per_request
+
+    def _resolve_workspace_id(self, workspace_id: Optional[int] = None) -> int:
+        """Resolve the workspace ID for a request: an explicit argument wins,
+        otherwise fall back to the client's workspace (per-request header or env).
+        Raises a transport-specific error if neither is set."""
+        ws = workspace_id if workspace_id is not None else self.workspace_id
+        if not ws:
+            hint = (
+                "Send a valid integer in the x-bigeye-workspace-id request header."
+                if self.per_request
+                else "Set the BIGEYE_WORKSPACE_ID environment variable."
+            )
+            raise ValueError(f"Workspace ID not configured. {hint}")
+        return int(ws)
+
     async def make_request(
         self, 
         path: str, 
@@ -194,7 +212,7 @@ class BigeyeAPIClient:
 
     async def fetch_issues(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         currentStatus: Optional[List[str]] = None,
         schemaNames: Optional[List[str]] = None,
         assigneeIds: Optional[List[int]] = None,
@@ -227,6 +245,7 @@ class BigeyeAPIClient:
         Returns:
             Dictionary containing the issues
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         payload = {
             "workspaceId": workspace_id
         }
@@ -397,10 +416,10 @@ class BigeyeAPIClient:
 
     async def search_issues_by_name(
         self,
-        workspace_id: int,
         name_query: str,
         statuses: Optional[List[str]] = None,
-        exact_match: bool = False
+        exact_match: bool = False,
+        workspace_id: Optional[int] = None
     ) -> Dict[str, Any]:
         """Search for issues by their name field (display name/reference).
 
@@ -409,15 +428,16 @@ class BigeyeAPIClient:
         not the internal 'id' field.
 
         Args:
-            workspace_id: The ID of the workspace to search in
             name_query: The name (or partial name) to search for
             statuses: Optional list of issue statuses to filter by
             exact_match: If True, only return exact name matches. If False (default),
                         returns partial matches (case-insensitive)
+            workspace_id: The ID of the workspace to search in
 
         Returns:
             Dictionary containing matching issues with essential metadata
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         print(f"[BIGEYE API DEBUG] Searching for issues with name containing: {name_query}", file=sys.stderr)
 
         # Fetch all issues with the given status filters
@@ -458,21 +478,22 @@ class BigeyeAPIClient:
     async def merge_issues(
         self,
         issue_ids: List[int],
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         existing_incident_id: Optional[int] = None,
         incident_name: Optional[str] = None
     ) -> Dict[str, Any]:
         """Merge multiple issues into a single incident.
-        
+
         Args:
             issue_ids: List of issue IDs to merge
             workspace_id: The ID of the workspace containing the issues
             existing_incident_id: Optional ID of an existing incident to merge issues into
             incident_name: Optional name for the incident (new or existing)
-            
+
         Returns:
             Dictionary containing the merge response with the created/updated incident
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         # Build the where clause with issue IDs and workspace ID
         where_clause = {
             "ids": issue_ids,
@@ -649,7 +670,7 @@ class BigeyeAPIClient:
         
     async def unmerge_issues(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         issue_ids: Optional[List[int]] = None,
         parent_issue_ids: Optional[List[int]] = None,
         assignee_id: Optional[int] = None,
@@ -671,6 +692,7 @@ class BigeyeAPIClient:
         Returns:
             Dictionary containing the unmerge response
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         # Build the where clause
         where_clause = {
             "workspaceId": workspace_id
@@ -821,13 +843,14 @@ class BigeyeAPIClient:
         Returns:
             Dictionary containing the created node details
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         payload = {
             "nodeType": node_type,
             "nodeName": node_name,
             "nodeContainerName": node_container_name,
             "rebuildGraph": rebuild_graph
         }
-        
+
         if workspace_id is not None:
             payload["workspaceId"] = workspace_id
             
@@ -1114,22 +1137,23 @@ class BigeyeAPIClient:
         
     async def get_catalog_tables(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         schema_name: Optional[str] = None,
         warehouse_name: Optional[str] = None,
         page_size: int = 100
     ) -> Dict[str, Any]:
         """Get tables from Bigeye's catalog.
-        
+
         Args:
             workspace_id: The workspace ID
             schema_name: Optional schema name to filter by
             warehouse_name: Optional warehouse name to filter by
             page_size: Number of results per page
-            
+
         Returns:
             Dictionary containing catalog tables
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         payload = {
             "workspaceId": workspace_id,
             "pageSize": page_size
@@ -1149,24 +1173,25 @@ class BigeyeAPIClient:
         
     async def get_issues_for_table(
         self,
-        workspace_id: int,
         table_name: str,
         warehouse_name: Optional[str] = None,
         schema_name: Optional[str] = None,
-        currentStatus: Optional[List[str]] = None
+        currentStatus: Optional[List[str]] = None,
+        workspace_id: Optional[int] = None
     ) -> Dict[str, Any]:
         """Get issues for a specific table.
-        
+
         Args:
-            workspace_id: The workspace ID
             table_name: Table name to filter by
             warehouse_name: Optional warehouse name
             schema_name: Optional schema name
             currentStatus: Optional list of issue statuses
-            
+            workspace_id: The workspace ID
+
         Returns:
             Dictionary containing issues for the table
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         # First, try to find the table in the catalog
         catalog_result = await self.get_catalog_tables(
             workspace_id=workspace_id,
@@ -1283,7 +1308,7 @@ class BigeyeAPIClient:
         
     async def get_table_metrics(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         table_ids: Optional[List[int]] = None,
         schema_ids: Optional[List[int]] = None,
         source_ids: Optional[List[int]] = None,
@@ -1305,6 +1330,7 @@ class BigeyeAPIClient:
         Returns:
             Dictionary containing metrics matching the filters
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         params: Dict[str, Any] = {
             "workspaceId": workspace_id,
             "pageSize": page_size,
@@ -1333,7 +1359,7 @@ class BigeyeAPIClient:
 
     async def get_sources(
         self,
-        workspace_id: int
+        workspace_id: Optional[int] = None
     ) -> Dict[str, Any]:
         """Get all data sources (warehouses) connected to the workspace.
 
@@ -1343,6 +1369,7 @@ class BigeyeAPIClient:
         Returns:
             Dictionary containing list of data sources
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         return await self.make_request(
             f"/api/v1/workspaces/{workspace_id}/sources",
             method="GET"
@@ -1376,24 +1403,25 @@ class BigeyeAPIClient:
     
     async def search_schemas(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         schema_name: Optional[str] = None,
         warehouse_ids: Optional[List[int]] = None
     ) -> Dict[str, Any]:
         """Search for schemas in Bigeye.
-        
+
         Args:
             workspace_id: Required workspace ID for the search
             schema_name: Optional schema name to filter by (supports partial matching)
             warehouse_ids: Optional list of warehouse IDs to filter by
-            
+
         Returns:
             Dictionary containing schemas
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         params = {
             "workspaceId": workspace_id
         }
-        
+
         if schema_name:
             params["schema"] = schema_name
             
@@ -1410,28 +1438,29 @@ class BigeyeAPIClient:
     
     async def search_tables(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         table_name: Optional[str] = None,
         schema_names: Optional[List[str]] = None,
         warehouse_ids: Optional[List[int]] = None,
         include_columns: bool = False
     ) -> Dict[str, Any]:
         """Search for tables in Bigeye.
-        
+
         Args:
             workspace_id: Required workspace ID for the search
             table_name: Optional table name to filter by (supports partial matching)
             schema_names: Optional list of schema names to filter by
             warehouse_ids: Optional list of warehouse IDs to filter by
             include_columns: Whether to include column information in the response
-            
+
         Returns:
             Dictionary containing tables
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         params = {
             "workspaceId": workspace_id
         }
-        
+
         if table_name:
             params["tableName"] = table_name
             
@@ -1454,20 +1483,21 @@ class BigeyeAPIClient:
     
     async def fetch_tables(
         self,
-        workspace_id: int,
         table_ids: List[int],
-        include_columns: bool = False
+        include_columns: bool = False,
+        workspace_id: Optional[int] = None
     ) -> Dict[str, Any]:
         """Fetch specific tables by ID.
 
         Args:
-            workspace_id: Required workspace ID
             table_ids: List of table IDs to fetch
             include_columns: Whether to include column information
+            workspace_id: Required workspace ID
 
         Returns:
             Dictionary containing tables
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         payload: Dict[str, Any] = {
             "workspaceId": workspace_id,
             "tableIds": table_ids,
@@ -1485,28 +1515,29 @@ class BigeyeAPIClient:
 
     async def search_columns(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         column_name: Optional[str] = None,
         table_names: Optional[List[str]] = None,
         schema_names: Optional[List[str]] = None,
         warehouse_ids: Optional[List[int]] = None
     ) -> Dict[str, Any]:
         """Search for columns in Bigeye.
-        
+
         Args:
             workspace_id: Required workspace ID for the search
             column_name: Optional column name to filter by (supports partial matching)
             table_names: Optional list of table names to filter by
             schema_names: Optional list of schema names to filter by
             warehouse_ids: Optional list of warehouse IDs to filter by
-            
+
         Returns:
             Dictionary containing columns
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         params = {
             "workspaceId": workspace_id
         }
-        
+
         if column_name:
             params["columnName"] = column_name
             
@@ -1548,6 +1579,9 @@ class BigeyeAPIClient:
         Returns:
             The raw SearchResponse: {"results": [{<oneOfKey>: {...}}, ...]}.
         """
+        # Workspace travels in the x-bigeye-workspace-id header (added by
+        # make_request from self.workspace_id); validate it's present.
+        self._resolve_workspace_id()
         payload: Dict[str, Any] = {"search": search}
         if data_node_types:
             payload["types"] = [{"dataNodeType": t} for t in data_node_types]
@@ -1805,7 +1839,7 @@ class BigeyeAPIClient:
     async def search_lineage_v2(
         self,
         search_string: str,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         limit: int = 100
     ) -> Dict[str, Any]:
         """Search for lineage nodes using the v2 search API.
@@ -1829,6 +1863,7 @@ class BigeyeAPIClient:
             - "CUSTOMER*" - Find all objects starting with CUSTOMER
             - "PROD_REPL/DIM_CUSTOMER/CUSTOMER_ID" - Find specific column
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         print(f"[BIGEYE API DEBUG] === search_lineage_v2 called ===", file=sys.stderr)
         print(f"[BIGEYE API DEBUG] Parameters:", file=sys.stderr)
         print(f"[BIGEYE API DEBUG]   search_string: '{search_string}' (type: {type(search_string)})", file=sys.stderr)
@@ -1868,7 +1903,7 @@ class BigeyeAPIClient:
 
     async def fetch_data_classes(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         search: Optional[str] = None,
         sensitivities: Optional[List[str]] = None,
         page_size: Optional[int] = None,
@@ -1883,6 +1918,7 @@ class BigeyeAPIClient:
             page_size: Optional number of results per page
             page_cursor: Optional pagination cursor
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         payload: Dict[str, Any] = {
             "workspaceId": workspace_id,
         }
@@ -1903,7 +1939,7 @@ class BigeyeAPIClient:
 
     async def fetch_scan_findings(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         table_ids: Optional[List[int]] = None,
         column_ids: Optional[List[int]] = None,
         data_class_ids: Optional[List[int]] = None,
@@ -1926,6 +1962,7 @@ class BigeyeAPIClient:
             page_size: Optional number of results per page
             page_cursor: Optional pagination cursor
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         payload: Dict[str, Any] = {
             "workspaceId": workspace_id,
         }
@@ -1954,7 +1991,7 @@ class BigeyeAPIClient:
 
     async def fetch_snapshot_findings(
         self,
-        workspace_id: int,
+        workspace_id: Optional[int] = None,
         table_ids: Optional[List[int]] = None,
         column_ids: Optional[List[int]] = None,
         schema_ids: Optional[List[int]] = None,
@@ -1973,6 +2010,7 @@ class BigeyeAPIClient:
         Unlike aggregate findings (current state across all runs), snapshot findings
         show results from specific scan runs.
         """
+        workspace_id = self._resolve_workspace_id(workspace_id)
         payload: Dict[str, Any] = {"workspaceId": workspace_id}
         if table_ids:
             payload["tableIds"] = table_ids

--- a/server.py
+++ b/server.py
@@ -324,7 +324,6 @@ debug_print(f"Telemetry {'enabled' if _telemetry.enabled else 'disabled'}")
 
 async def _resolve_table(
     client: BigeyeAPIClient,
-    workspace_id: int,
     table_name: str,
     schema_name: Optional[str] = None,
     include_columns: bool = False,
@@ -346,7 +345,6 @@ async def _resolve_table(
 
     # Attempt 1: search with both filters
     result = await client.search_tables(
-        workspace_id=workspace_id,
         table_name=uc_table,
         schema_names=[uc_schema] if uc_schema else None,
         include_columns=include_columns,
@@ -361,7 +359,6 @@ async def _resolve_table(
             "retrying without schema filter (suffix match)"
         )
         result = await client.search_tables(
-            workspace_id=workspace_id,
             table_name=uc_table,
             include_columns=include_columns,
         )
@@ -376,7 +373,6 @@ async def _resolve_table(
             f"Still no results; retrying with just table_name={uc_table}"
         )
         result = await client.search_tables(
-            workspace_id=workspace_id,
             table_name=uc_table,
             include_columns=include_columns,
         )
@@ -427,6 +423,7 @@ def get_api_client() -> BigeyeAPIClient:
             api_url=creds.get("url") or config["api_url"],
             api_key=creds.get("api_key"),
             workspace_id=creds.get("workspace_id"),
+            per_request=True,
         )
     return api_client
 
@@ -434,17 +431,18 @@ def get_api_client() -> BigeyeAPIClient:
 @mcp.resource("bigeye://auth/status")
 async def auth_status() -> str:
     """Current authentication status"""
-    workspace_id = config.get('workspace_id')
-    if not workspace_id or not config.get('api_key'):
+    client = get_api_client()
+    workspace_id = client.workspace_id
+    if not workspace_id or not client.api_key:
         return """ERROR: Bigeye credentials not configured.
-        
+
 Please configure credentials in your Claude Desktop config file.
 See README for setup instructions."""
-    
+
     return f"""Connected to Bigeye:
-- Instance: {config['api_url']}
+- Instance: {client.api_url}
 - Workspace ID: {workspace_id}
-- Status: ✓ Authenticated via environment variables"""
+- Status: ✓ Authenticated"""
 
 # Note: Dynamic authentication has been removed.
 # Credentials must be provided via environment variables.
@@ -480,12 +478,12 @@ def get_config_resource() -> Dict[str, Any]:
 async def get_issues_resource() -> Dict[str, Any]:
     """Get all issues from the configured workspace."""
     client = get_api_client()
-    workspace_id = config.get('workspace_id')
+    workspace_id = client.workspace_id
     if not workspace_id:
         return {"error": "No workspace ID configured"}
-    
+
     debug_print(f"Fetching all issues for workspace {workspace_id}")
-    result = await client.fetch_issues(workspace_id=workspace_id)
+    result = await client.fetch_issues()
     
     issue_count = len(result.get("issues", []))
     debug_print(f"Found {issue_count} issues")
@@ -500,15 +498,14 @@ async def get_active_issues_resource() -> Dict[str, Any]:
     Provides a focused view of current problems that need attention.
     """
     client = get_api_client()
-    workspace_id = config.get('workspace_id')
+    workspace_id = client.workspace_id
     if not workspace_id:
         return {"error": "No workspace ID configured"}
-    
+
     debug_print(f"Fetching active issues for workspace {workspace_id}")
-    
+
     # Fetch only NEW and ACKNOWLEDGED issues
     result = await client.fetch_issues(
-        workspace_id=workspace_id,
         currentStatus=["ISSUE_STATUS_NEW", "ISSUE_STATUS_ACKNOWLEDGED"],
         page_size=50,  # Limit to most recent 50 active issues
         include_full_history=False  # Keep response size manageable
@@ -599,15 +596,14 @@ async def get_recent_issues_resource() -> Dict[str, Any]:
     to help track resolution patterns and recent activity.
     """
     client = get_api_client()
-    workspace_id = config.get('workspace_id')
+    workspace_id = client.workspace_id
     if not workspace_id:
         return {"error": "No workspace ID configured"}
-    
+
     debug_print(f"Fetching recent issues for workspace {workspace_id}")
-    
+
     # Fetch all issues (we'll filter by date client-side since the API doesn't have date filters)
     result = await client.fetch_issues(
-        workspace_id=workspace_id,
         page_size=100,  # Get more issues to ensure we have recent ones
         include_full_history=False
     )
@@ -866,17 +862,9 @@ async def list_issues(
     """
 
     client = get_api_client()
-    workspace_id = config.get('workspace_id')
 
-    # Safety check
-    if not workspace_id:
-        return {
-            'error': 'Workspace ID not configured',
-            'hint': 'Check your Claude Desktop configuration'
-        }
-
-    debug_print(f"Fetching issues for workspace {workspace_id}")
-    debug_print(f"Config state - Instance: {config['api_url']}, Workspace: {workspace_id}, Has API key: {bool(config.get('api_key'))}")
+    debug_print(f"Fetching issues for workspace {client.workspace_id}")
+    debug_print(f"Config state - Instance: {client.api_url}, Workspace: {client.workspace_id}, Has API key: {bool(client.api_key)}")
     debug_print(f"compact={compact}, max_issues={max_issues}")
 
     if statuses:
@@ -887,7 +875,6 @@ async def list_issues(
         debug_print(f"Filtering by assignee IDs: {assignee_ids}")
 
     result = await client.fetch_issues(
-        workspace_id=workspace_id,
         currentStatus=statuses,
         schemaNames=schema_names,
         assigneeIds=assignee_ids,
@@ -943,14 +930,6 @@ async def search_issues(
     """
 
     client = get_api_client()
-    workspace_id = config.get('workspace_id')
-
-    # Safety check
-    if not workspace_id:
-        return {
-            'error': 'Workspace ID not configured',
-            'hint': 'Check your Claude Desktop configuration'
-        }
 
     debug_print(f"Searching for issues with name: {name_query}")
     debug_print(f"Exact match: {exact_match}")
@@ -959,7 +938,6 @@ async def search_issues(
         debug_print(f"Filtering by statuses: {statuses}")
 
     result = await client.search_issues_by_name(
-        workspace_id=workspace_id,
         name_query=name_query,
         statuses=statuses,
         exact_match=exact_match
@@ -994,12 +972,6 @@ async def search_schemas(
         limit: Maximum number of results to return (default: 50)
     """
     client = get_api_client()
-    if not client.workspace_id:
-        return {
-            'error': 'Workspace ID not configured',
-            'hint': 'Check your Claude Desktop configuration'
-        }
-
     debug_print(f"Catalog schema search for: {query}")
     response = await client.catalog_search(
         search=query,
@@ -1040,12 +1012,6 @@ async def search_tables(
         limit: Maximum number of results to return (default: 50)
     """
     client = get_api_client()
-    if not client.workspace_id:
-        return {
-            'error': 'Workspace ID not configured',
-            'hint': 'Check your Claude Desktop configuration'
-        }
-
     debug_print(f"Catalog table search for: {query}")
     response = await client.catalog_search(
         search=query,
@@ -1088,12 +1054,6 @@ async def search_columns(
         limit: Maximum number of results to return (default: 50)
     """
     client = get_api_client()
-    if not client.workspace_id:
-        return {
-            'error': 'Workspace ID not configured',
-            'hint': 'Check your Claude Desktop configuration'
-        }
-
     debug_print(f"Catalog column search for: {query}")
     response = await client.catalog_search(
         search=query,
@@ -1165,20 +1125,11 @@ async def list_table_issues(
     """
     
     client = get_api_client()
-    workspace_id = config.get('workspace_id')
-    
-    # Safety check
-    if not workspace_id:
-        return {
-            'error': 'Workspace ID not set',
-            'hint': 'Authentication may be incomplete. Try re-authenticating.'
-        }
-    
-    debug_print(f"Fetching issues for table {table_name} in workspace {workspace_id}")
-    
+
+    debug_print(f"Fetching issues for table {table_name} in workspace {client.workspace_id}")
+
     try:
         result = await client.get_issues_for_table(
-            workspace_id=workspace_id,
             table_name=table_name,
             warehouse_name=warehouse_name,
             schema_name=schema_name,
@@ -1250,7 +1201,6 @@ async def create_incident(
     try:
         result = await client.merge_issues(
             issue_ids=issue_ids,
-            workspace_id=config.get('workspace_id'),
             existing_incident_id=existing_incident_id,
             incident_name=incident_name
         )
@@ -1361,11 +1311,10 @@ async def delete_incident_members(
         }
     
     client = get_api_client()
-    debug_print(f"Unmerging issues in workspace {config.get('workspace_id')}")
-    
+    debug_print(f"Unmerging issues in workspace {client.workspace_id}")
+
     try:
         result = await client.unmerge_issues(
-            workspace_id=config.get('workspace_id'),
             issue_ids=issue_ids,
             parent_issue_ids=parent_issue_ids,
             assignee_id=assignee_id,
@@ -1391,26 +1340,18 @@ async def list_table_metrics(
         schema_name: Optional schema name to narrow the search
     """
     client = get_api_client()
-    workspace_id = config.get('workspace_id')
-
-    if not workspace_id:
-        return {
-            'error': 'Workspace ID not configured',
-            'hint': 'Check your Claude Desktop configuration'
-        }
 
     debug_print(f"Fetching metrics for table {table_name}")
 
     try:
         # Resolve table name → table ID (GET /api/v1/metrics requires tableIds, not tableName)
-        table = await _resolve_table(client, workspace_id, table_name, schema_name)
+        table = await _resolve_table(client, table_name, schema_name)
         if table.get("error"):
             return table
 
         table_id = table["id"]
 
         result = await client.get_table_metrics(
-            workspace_id=workspace_id,
             table_ids=[table_id],
         )
 
@@ -1458,18 +1399,11 @@ async def list_table_metrics(
 async def list_data_sources() -> Dict[str, Any]:
     """List all data sources (warehouses) connected to Bigeye. Returns source names, types (SNOWFLAKE, DATABRICKS, etc.), and connection details. Prefer list_sources (knowledgebase) for faster cached results."""
     client = get_api_client()
-    workspace_id = config.get('workspace_id')
-
-    if not workspace_id:
-        return {
-            'error': 'Workspace ID not configured',
-            'hint': 'Check your Claude Desktop configuration'
-        }
 
     debug_print("Fetching data sources")
 
     try:
-        result = await client.get_sources(workspace_id=workspace_id)
+        result = await client.get_sources()
         return result
     except Exception as e:
         return {
@@ -2351,41 +2285,31 @@ async def search_lineage_nodes(
         node_type: Optional node type filter: "DATA_NODE_TYPE_TABLE", "DATA_NODE_TYPE_COLUMN", "DATA_NODE_TYPE_CUSTOM"
         limit: Maximum number of results to return (default: 20)
     """
-    # Use configured workspace_id if not provided
-    if workspace_id is None:
-        workspace_id = config.get('workspace_id')
-        if not workspace_id:
+    client = get_api_client()
+    if not client:
+        return {'error': 'Failed to get API client'}
+
+    # If the caller supplied a workspace_id, coerce it to int; otherwise the
+    # client resolves it from the per-request header / configured workspace.
+    if workspace_id is not None:
+        try:
+            workspace_id = int(workspace_id)
+        except (ValueError, TypeError):
             return {
-                'error': 'Workspace ID not configured',
-                'hint': 'Check your Claude Desktop configuration for BIGEYE_WORKSPACE_ID'
+                "error": True,
+                "message": f"workspace_id must be a valid integer, got: {workspace_id} (type: {type(workspace_id)})"
             }
-    
+
     # Enhanced debug logging
     debug_print(f"=== search_lineage_nodes called ===")
-    debug_print(f"  workspace_id: {workspace_id} (type: {type(workspace_id)})")
+    debug_print(f"  workspace_id (override): {workspace_id}")
+    debug_print(f"  client.workspace_id: {client.workspace_id}")
     debug_print(f"  search_string: '{search_string}'")
     debug_print(f"  node_type: {node_type}")
     debug_print(f"  limit: {limit}")
     debug_print(f"  auth_client.is_authenticated: {auth_client.is_authenticated}")
-    debug_print(f"  config.get('workspace_id'): {config.get('workspace_id')}")
-    
-    
-    client = get_api_client()
-    if not client:
-        return {'error': 'Failed to get API client'}
-    
-    # Ensure workspace_id is an integer
-    try:
-        workspace_id = int(workspace_id)
-        debug_print(f"Converted workspace_id to int: {workspace_id}")
-    except (ValueError, TypeError) as e:
-        error_msg = f"workspace_id must be a valid integer, got: {workspace_id} (type: {type(workspace_id)})"
-        debug_print(f"ERROR: {error_msg}")
-        return {
-            "error": True,
-            "message": error_msg
-        }
-        
+
+
     try:
         # Normalize the search string (trim whitespace around slashes)
         normalized_search = search_string.strip().replace(' / ', '/').replace('/ ', '/').replace(' /', '/')
@@ -2505,7 +2429,6 @@ async def lineage_explore_catalog(
     try:
         # Get tables from catalog
         result = await client.get_catalog_tables(
-            workspace_id=config.get('workspace_id'),
             schema_name=schema_name,
             warehouse_name=warehouse_name,
             page_size=page_size
@@ -3013,14 +2936,6 @@ async def create_metric(
         group_bys: Optional list of column names to group by
     """
     client = get_api_client()
-    workspace_id = config.get("workspace_id")
-
-    # 1. Check workspace_id
-    if not workspace_id:
-        return {
-            "error": "Workspace ID not configured",
-            "hint": "Check your Claude Desktop configuration for BIGEYE_WORKSPACE_ID",
-        }
 
     # 2. Validate metric_type
     metric_upper = metric_type.upper()
@@ -3096,13 +3011,11 @@ async def create_metric(
     try:
         if table_id:
             table_result = await client.fetch_tables(
-                workspace_id=workspace_id,
                 table_ids=[table_id],
                 include_columns=True,
             )
         else:
             table_result = await client.search_tables(
-                workspace_id=workspace_id,
                 table_name=table_name,
                 schema_names=[schema_name] if schema_name else None,
                 include_columns=True,
@@ -3231,13 +3144,6 @@ async def _compute_dimension_coverage(
     ambiguous name-based lookups). Otherwise falls back to name search.
     """
     client = get_api_client()
-    workspace_id = config.get("workspace_id")
-
-    if not workspace_id:
-        return {
-            "error": "Workspace ID not configured",
-            "hint": "Check your Claude Desktop configuration",
-        }
 
     debug_print(f"Computing dimension coverage for table {table_name or table_id}")
 
@@ -3282,7 +3188,6 @@ async def _compute_dimension_coverage(
         # 3. Fetch column metadata — by ID if available, otherwise name search
         if table_id:
             table_result = await client.fetch_tables(
-                workspace_id=workspace_id,
                 table_ids=[table_id],
                 include_columns=True,
             )
@@ -3292,7 +3197,7 @@ async def _compute_dimension_coverage(
             table = tables[0]
         else:
             table = await _resolve_table(
-                client, workspace_id, table_name, schema_name, include_columns=True,
+                client, table_name, schema_name, include_columns=True,
             )
             if table.get("error"):
                 return table
@@ -3316,7 +3221,6 @@ async def _compute_dimension_coverage(
         if not table_id:
             return {"error": f"Table '{table_name}' found but has no ID"}
         metrics_result = await client.get_table_metrics(
-            workspace_id=workspace_id,
             table_ids=[table_id],
         )
         metrics = metrics_result.get("metrics", [])
@@ -3864,18 +3768,10 @@ async def list_data_classes(
         Dictionary containing data classes with their names, sensitivity levels, and descriptions
     """
     client = get_api_client()
-    workspace_id = config.get("workspace_id")
-
-    if not workspace_id:
-        return {
-            "error": "Workspace ID not configured",
-            "hint": "Check your Claude Desktop configuration for BIGEYE_WORKSPACE_ID",
-        }
 
     try:
         debug_print(f"Fetching data classes (search={search}, sensitivities={sensitivities})")
         result = await client.fetch_data_classes(
-            workspace_id=workspace_id,
             search=search,
             sensitivities=sensitivities,
             page_size=page_size,
@@ -3942,13 +3838,9 @@ async def get_table_sensitivity_findings(
         page_cursor: Pagination cursor from a previous response
     """
     client = get_api_client()
-    workspace_id = config.get("workspace_id")
-
-    if not workspace_id:
-        return {"error": True, "message": "Workspace ID not configured"}
 
     try:
-        table = await _resolve_table(client, workspace_id, table_name, schema_name)
+        table = await _resolve_table(client, table_name, schema_name)
         if table.get("error"):
             return table
 
@@ -3971,7 +3863,6 @@ async def get_table_sensitivity_findings(
 
         if finding_type == "snapshot":
             result = await client.fetch_snapshot_findings(
-                workspace_id=int(workspace_id),
                 table_ids=[table_id],
                 sensitivities=normalized_sensitivities,
                 positive_or_negative_findings=positive_or_negative,
@@ -3980,7 +3871,6 @@ async def get_table_sensitivity_findings(
             )
         else:
             result = await client.fetch_scan_findings(
-                workspace_id=int(workspace_id),
                 table_ids=[table_id],
                 sensitivities=normalized_sensitivities,
                 positive_or_negative_findings=positive_or_negative,
@@ -4047,20 +3937,12 @@ async def get_scan_findings(
         page_cursor: Cursor for pagination
     """
     client = get_api_client()
-    workspace_id = config.get("workspace_id")
-
-    if not workspace_id:
-        return {
-            "error": "Workspace ID not configured",
-            "hint": "Check your Claude Desktop configuration for BIGEYE_WORKSPACE_ID",
-        }
 
     positive_or_negative = "TRUE" if positive_only else None
 
     try:
         if finding_type == "snapshot":
             result = await client.fetch_snapshot_findings(
-                workspace_id=workspace_id,
                 table_ids=table_ids,
                 column_ids=column_ids,
                 data_class_ids=data_class_ids,
@@ -4071,7 +3953,6 @@ async def get_scan_findings(
             )
         else:
             result = await client.fetch_scan_findings(
-                workspace_id=workspace_id,
                 table_ids=table_ids,
                 column_ids=column_ids,
                 data_class_ids=data_class_ids,


### PR DESCRIPTION
## Problem

When connecting through the hosted MCP gateway (`https://mcpgateway.bigeye.com/mcp`) with per-request headers:

```
Authorization: apikey bigeye_pak_...
x-bigeye-workspace-id: 85
```

`get_current_user` works, but `list_issues` and most other tools fail with **"Workspace ID not configured."**

## Root cause

The middleware reads the `x-bigeye-workspace-id` header correctly and `get_api_client()` builds a `BigeyeAPIClient` whose `.workspace_id` is set for the request. But most tools ignored that and read `config.get('workspace_id')` instead — i.e. the `BIGEYE_WORKSPACE_ID` env var, which is unset on the gateway. `get_current_user` was the exception only because `/auth` needs no workspace. (Commit `173c054` had already fixed this for the three catalog search tools; the rest were never updated.)

## Fix — centralize resolution in the client (Level 2)

**`bigeye_api.py`**
- Add a `per_request` flag to `BigeyeAPIClient.__init__` and a single `_resolve_workspace_id()` helper that defaults to `self.workspace_id` and raises a **transport-specific** error when none is set (header hint for HTTP, env-var hint for stdio).
- Make `workspace_id` optional on all workspace-taking methods (`fetch_issues`, `search_*`, `merge_issues`/`unmerge_issues`, `get_sources`, `get_table_metrics`, `fetch_*_findings`, `search_lineage_v2`, etc.); each resolves via the helper as its first line. `catalog_search` validates the same way.
- Three signatures were reordered (`search_issues_by_name`, `get_issues_for_table`, `fetch_tables`) where a required arg followed `workspace_id`; all callers pass by keyword.

**`server.py`**
- `get_api_client()` marks header-built clients `per_request=True`.
- Strip the `config.get('workspace_id')` resolve/guard/pass-through from the tools so they rely on the client; resources keep a light guard sourced from `client.workspace_id`. `_resolve_table()` derives the workspace from the client. `search_lineage_nodes` keeps its optional override param.

Works in both transports: HTTP per-request (header) and stdio (env var).

## Verification

- Both files compile.
- Resolver returns header/override/env workspaces and raises the correct transport-specific message when missing.
- Confirmed methods inject the resolved workspace into the request body (`fetch_issues` → `workspaceId:85`), URL path (`get_sources` → `/workspaces/85/sources`), respect overrides (`search_lineage_v2` → 99), and that `catalog_search` validates without a body field (workspace travels in the header).

> Note: needs to be rebuilt/deployed to whatever serves `mcpgateway.bigeye.com/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)