### PR TITLE
Add get_ai_agent_trust_hub tool to MCP server

### DIFF
--- a/bigeye_api.py
+++ b/bigeye_api.py
@@ -1455,6 +1455,128 @@ class BigeyeAPIClient:
             method="GET"
         )
 
+    async def list_ai_agents(
+        self,
+        workspace_id: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """List AI agents registered in the workspace.
+
+        Returns each agent's identity, platform, status, trust scores
+        (quality/sensitivity/governance), and connected catalog sources.
+
+        Args:
+            workspace_id: The workspace ID
+
+        Returns:
+            Dictionary containing the list of AI agents (key "aiAgents")
+        """
+        workspace_id = self._resolve_workspace_id(workspace_id)
+        return await self.make_request(
+            "/api/v1/ai-agents/list",
+            method="POST",
+            json_data={"workspaceId": workspace_id}
+        )
+
+    async def get_ai_agent(
+        self,
+        agent_id: int
+    ) -> Dict[str, Any]:
+        """Get a single AI agent by its numeric Bigeye id.
+
+        Args:
+            agent_id: The Bigeye id of the AI agent
+
+        Returns:
+            Dictionary containing the AI agent's identity, platform, status,
+            trust scores, and connected catalog sources
+        """
+        return await self.make_request(
+            f"/api/v1/ai-agents/{agent_id}",
+            method="GET"
+        )
+
+    async def list_agent_conversations(
+        self,
+        agent_external_id: Optional[str] = None,
+        workspace_id: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """List AI agent conversations in the workspace.
+
+        Each conversation carries its cost, token usage, the user who ran it
+        (if known), and a summary of the tables it accessed along with their
+        sensitivity, monitoring, and issue status.
+
+        Args:
+            agent_external_id: Optional external id of an agent, as reported
+                by its platform. Narrows the results to that agent's
+                conversations; omit for every conversation in the workspace.
+            workspace_id: The workspace ID
+
+        Returns:
+            Dictionary containing the list of conversations (key
+            "agentConversations")
+        """
+        workspace_id = self._resolve_workspace_id(workspace_id)
+        payload: Dict[str, Any] = {"workspaceId": workspace_id}
+        if agent_external_id:
+            payload["agentExternalId"] = agent_external_id
+        return await self.make_request(
+            "/api/v1/agent-conversations/list",
+            method="POST",
+            json_data=payload
+        )
+
+    async def get_agent_conversation(
+        self,
+        conversation_id: int
+    ) -> Dict[str, Any]:
+        """Get a single AI agent conversation by its numeric Bigeye id.
+
+        Args:
+            conversation_id: The Bigeye id of the conversation
+
+        Returns:
+            Dictionary containing the conversation's cost, token usage, user,
+            and accessed-data summary
+        """
+        return await self.make_request(
+            f"/api/v1/agent-conversations/{conversation_id}",
+            method="GET"
+        )
+
+    async def get_access_decision_summary(
+        self,
+        agent_external_id: Optional[str] = None,
+        workspace_id: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """Get the aggregate table/column access summary for AI agents in the workspace.
+
+        Returns one row per table or column that an AI agent has accessed,
+        with the access count, number of distinct agents that touched it,
+        monitor and finding counts, max sensitivity, and certification
+        status. This is aggregate only — it cannot say which users made the
+        accesses.
+
+        Args:
+            agent_external_id: Optional external id of an agent, as reported
+                by its platform. Narrows the summary to that agent's
+                accesses; omit for every agent in the workspace.
+            workspace_id: The workspace ID
+
+        Returns:
+            Dictionary containing the list of access summaries (key
+            "summaries")
+        """
+        workspace_id = self._resolve_workspace_id(workspace_id)
+        payload: Dict[str, Any] = {"workspaceId": workspace_id}
+        if agent_external_id:
+            payload["agentExternalId"] = agent_external_id
+        return await self.make_request(
+            "/api/v1/access-decision/summary",
+            method="POST",
+            json_data=payload
+        )
+
     async def delete_lineage_node(
         self,
         node_id: int,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.28.1",
-    "mcp[cli]>=1.6.0",
+    "mcp[cli]>=1.6.0,<2.0.0",
     "cryptography>=43.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "httpx>=0.28.1",
-    "mcp[cli]>=1.6.0,<2.0.0",
+    "mcp[cli]>=1.12.0,<2.0.0",
     "cryptography>=43.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mcp[cli]>=1.12.0
+mcp[cli]>=1.12.0,<2.0.0
 httpx>=0.28.1
 cryptography>=43.0.0

--- a/server.py
+++ b/server.py
@@ -1822,7 +1822,7 @@ def _rollup_users(conversations: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             user_json["currency"] = rollup["currency"]
         user_json["agent_external_ids"] = sorted(rollup["agent_external_ids"])
         best = rollup["most_expensive_conversation"]
-        if best is not None and best.get("estimatedCost"):
+        if best is not None and best.get("estimatedCost") is not None:
             user_json["most_expensive_conversation"] = {
                 "id": best.get("id"),
                 "external_id": best.get("externalId"),
@@ -1898,13 +1898,31 @@ async def get_ai_agent_trust_hub(
     )
 
     sort_by = sort_by if sort_by in ("cost", "tokens") else "recent"
+    max_conversations = max(0, max_conversations)
 
     try:
+        # Resolve agent_id -> agent_external_id once, up front: both the
+        # object-access branch (to scope by agent) and the agent-drilldown
+        # branch need it, and an agent_id that matches nothing should be
+        # reported rather than silently falling through to another view.
+        resolved_agent_external_id = agent_external_id
+        agent_lookup_failed = False
+        if not resolved_agent_external_id and agent_id is not None:
+            agents_result = await client.list_ai_agents()
+            if agents_result.get("error"):
+                return agents_result
+            for agent in agents_result.get("aiAgents", []):
+                if agent.get("id") == agent_id:
+                    resolved_agent_external_id = agent.get("externalId")
+                    break
+            else:
+                agent_lookup_failed = True
+
         # 1. Object access: table_name / column_name / object_name.
         object_query = table_name or column_name or object_name
         if object_query:
             summary_result = await client.get_access_decision_summary(
-                agent_external_id=agent_external_id,
+                agent_external_id=resolved_agent_external_id,
             )
             if summary_result.get("error"):
                 return summary_result
@@ -1988,15 +2006,12 @@ async def get_ai_agent_trust_hub(
             }
 
         # 4. One agent's conversations and per-user breakdown.
-        resolved_agent_external_id = agent_external_id
-        if not resolved_agent_external_id and agent_id is not None:
-            agents_result = await client.list_ai_agents()
-            if agents_result.get("error"):
-                return agents_result
-            for agent in agents_result.get("aiAgents", []):
-                if agent.get("id") == agent_id:
-                    resolved_agent_external_id = agent.get("externalId")
-                    break
+        if agent_lookup_failed:
+            return {
+                "agent_id": agent_id,
+                "message": f"No AI agent found with id {agent_id} in this workspace. Call "
+                           "the tool with no arguments to list agents.",
+            }
 
         if resolved_agent_external_id:
             conversations_result = await client.list_agent_conversations(

--- a/server.py
+++ b/server.py
@@ -1682,6 +1682,404 @@ async def get_dataset_health_summary(
             "message": f"Error building dataset health summary: {str(e)}"
         }
 
+def _agent_summary_json(agent: Dict[str, Any]) -> Dict[str, Any]:
+    """Trim an AiAgent REST object to the fields the model needs."""
+    summary = {
+        "id": agent.get("id"),
+        "external_id": agent.get("externalId"),
+        "name": agent.get("name"),
+        "platform": agent.get("platform"),
+        "status": agent.get("status"),
+    }
+    if agent.get("description"):
+        summary["description"] = agent["description"]
+    trust_scores = agent.get("trustScores")
+    if trust_scores:
+        summary["trust_scores"] = trust_scores
+    sources = agent.get("sources")
+    if sources:
+        summary["data_sources"] = [
+            {"id": s.get("id"), "name": s.get("name"), "warehouse_vendor": s.get("warehouseVendor")}
+            for s in sources
+        ]
+    return summary
+
+
+def _conversation_summary_json(conversation: Dict[str, Any]) -> Dict[str, Any]:
+    """Trim an AgentConversation REST object to the fields the model needs."""
+    summary = {
+        "id": conversation.get("id"),
+        "external_id": conversation.get("externalId"),
+        "agent_external_id": conversation.get("agentExternalId"),
+        "timestamp": conversation.get("timestamp"),
+    }
+    username = conversation.get("username")
+    if username:
+        summary["username"] = username
+    user = conversation.get("user")
+    if user:
+        summary["user_id"] = user.get("id")
+        if user.get("displayName"):
+            summary["user_display_name"] = user["displayName"]
+    if conversation.get("tokenUsage") is not None:
+        summary["token_usage"] = conversation["tokenUsage"]
+    if conversation.get("estimatedCost") is not None:
+        summary["estimated_cost"] = conversation["estimatedCost"]
+    if conversation.get("currency"):
+        summary["currency"] = conversation["currency"]
+    if conversation.get("initialPrompt"):
+        summary["initial_prompt"] = conversation["initialPrompt"]
+
+    conv_summary = conversation.get("summary") or {}
+    if conv_summary:
+        summary["accessed_tables"] = [
+            {"id": t.get("id"), "name": t.get("name"), "schema_name": t.get("schemaName")}
+            for t in conv_summary.get("tables", [])
+        ]
+        if conv_summary.get("numIssues") is not None:
+            summary["num_issues"] = conv_summary["numIssues"]
+        if conv_summary.get("maxSensitivity"):
+            summary["max_sensitivity"] = conv_summary["maxSensitivity"]
+        if conv_summary.get("numFindings") is not None:
+            summary["num_findings"] = conv_summary["numFindings"]
+        if conv_summary.get("numMonitors") is not None:
+            summary["num_monitors"] = conv_summary["numMonitors"]
+        if conv_summary.get("hasScanCoverage") is not None:
+            summary["has_scan_coverage"] = conv_summary["hasScanCoverage"]
+        if conv_summary.get("numCertifiedTables") is not None:
+            summary["num_certified_tables"] = conv_summary["numCertifiedTables"]
+    return summary
+
+
+def _sort_conversations(conversations: List[Dict[str, Any]], sort_by: str) -> List[Dict[str, Any]]:
+    """Order conversations most-recent/most-expensive/heaviest-token-use first."""
+    if sort_by == "cost":
+        key = lambda c: c.get("estimatedCost") or 0
+    elif sort_by == "tokens":
+        key = lambda c: c.get("tokenUsage") or 0
+    else:
+        key = lambda c: c.get("timestamp") or 0
+    return sorted(conversations, key=key, reverse=True)
+
+
+def _conversation_user_key(conversation: Dict[str, Any]) -> str:
+    """Group a conversation by username, falling back to the linked account
+    or a single unattributed bucket, mirroring the chat tool's grouping."""
+    username = conversation.get("username")
+    if username:
+        return f"username:{username.lower()}"
+    user = conversation.get("user") or {}
+    if user.get("id") is not None:
+        return f"user:{user['id']}"
+    return "unattributed"
+
+
+def _rollup_users(conversations: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Roll conversations up by the human behind them: total cost/tokens,
+    agents used, and their single most expensive conversation. Sorted by
+    total cost so the biggest spenders come first."""
+    rollups: Dict[str, Dict[str, Any]] = {}
+    for conversation in conversations:
+        key = _conversation_user_key(conversation)
+        rollup = rollups.setdefault(key, {
+            "identity": conversation,
+            "conversation_count": 0,
+            "total_token_usage": 0,
+            "total_estimated_cost": 0.0,
+            "currency": None,
+            "agent_external_ids": set(),
+            "most_expensive_conversation": None,
+        })
+        rollup["conversation_count"] += 1
+        rollup["total_token_usage"] += conversation.get("tokenUsage") or 0
+        cost = conversation.get("estimatedCost") or 0
+        rollup["total_estimated_cost"] += cost
+        if rollup["currency"] is None and conversation.get("currency"):
+            rollup["currency"] = conversation["currency"]
+        agent_external_id = conversation.get("agentExternalId")
+        if agent_external_id:
+            rollup["agent_external_ids"].add(agent_external_id)
+        current_best = rollup["most_expensive_conversation"]
+        if current_best is None or cost > (current_best.get("estimatedCost") or 0):
+            rollup["most_expensive_conversation"] = conversation
+
+    users = []
+    for rollup in rollups.values():
+        identity = rollup["identity"]
+        user_json: Dict[str, Any] = {}
+        username = identity.get("username")
+        if username:
+            user_json["username"] = username
+        user = identity.get("user") or {}
+        if user.get("id") is not None:
+            user_json["user_id"] = user["id"]
+            if user.get("displayName"):
+                user_json["user_display_name"] = user["displayName"]
+        user_json["conversation_count"] = rollup["conversation_count"]
+        user_json["total_token_usage"] = rollup["total_token_usage"]
+        user_json["total_estimated_cost"] = rollup["total_estimated_cost"]
+        if rollup["currency"]:
+            user_json["currency"] = rollup["currency"]
+        user_json["agent_external_ids"] = sorted(rollup["agent_external_ids"])
+        best = rollup["most_expensive_conversation"]
+        if best is not None and best.get("estimatedCost"):
+            user_json["most_expensive_conversation"] = {
+                "id": best.get("id"),
+                "external_id": best.get("externalId"),
+                "estimated_cost": best.get("estimatedCost"),
+                "timestamp": best.get("timestamp"),
+            }
+        users.append(user_json)
+
+    users.sort(key=lambda u: u["total_estimated_cost"], reverse=True)
+    return users
+
+
+@mcp.tool()
+async def get_ai_agent_trust_hub(
+    agent_id: Optional[int] = None,
+    agent_external_id: Optional[str] = None,
+    username: Optional[str] = None,
+    conversation_id: Optional[int] = None,
+    table_name: Optional[str] = None,
+    column_name: Optional[str] = None,
+    object_name: Optional[str] = None,
+    sort_by: str = "recent",
+    max_conversations: int = 25,
+) -> Dict[str, Any]:
+    """Get information about AI agents in the workspace, the users who talked to them, their conversations, and the tables/columns those conversations accessed. Use this for questions like "which AI agents are running up cost", "who is talking to this agent", "what did this conversation touch", or "which agents have accessed this table".
+
+    With no arguments, returns the workspace overview: every registered agent
+    (identity, platform, trust scores, data sources, conversation count,
+    total token usage/cost, distinct accessed tables), every user who has
+    talked to an agent (conversation count, total cost/tokens, agents used,
+    their single most expensive conversation), and the most expensive
+    conversations in the workspace.
+
+    Narrow it by supplying one identifier, checked in this order:
+    - table_name, column_name, or object_name: aggregate access info for
+      matching tables/columns (access count, distinct agent count, monitor
+      and finding counts, max sensitivity, certification status), matched
+      case-insensitively as a substring. NOTE: this view is aggregate only —
+      it cannot say which specific users accessed the object, only how many
+      distinct agents did and how often.
+    - conversation_id: one conversation's cost, tokens, and the tables it
+      accessed with their sensitivity/monitoring/issue status.
+    - username: that user's conversations across every agent, with cost and
+      token totals.
+    - agent_id or agent_external_id: that agent's conversations and the
+      per-user breakdown of who has talked to it.
+
+    Conversation lists are capped by max_conversations; every response
+    reports the true count and whether the list was truncated. Use sort_by
+    to choose which conversations are kept when a list is capped.
+
+    Args:
+        agent_id: The numeric Bigeye id of an agent.
+        agent_external_id: The external id of an agent, as reported by its
+            platform. Equivalent to agent_id; use whichever you have.
+        username: A username recorded on conversations (usually an email).
+        conversation_id: The numeric Bigeye id of a conversation.
+        table_name: Part of a table name to look up aggregate access info by.
+        column_name: Part of a column name to look up aggregate access info by.
+        object_name: Part of a table or column name to look up aggregate
+            access info by (matches either).
+        sort_by: Which conversations to keep when a list is capped: "recent"
+            (default), "cost", or "tokens".
+        max_conversations: Maximum number of conversations to return in any
+            single list (default: 25).
+    """
+    client = get_api_client()
+
+    debug_print(
+        f"AI agent trust hub: agent_id={agent_id}, agent_external_id={agent_external_id}, "
+        f"username={username}, conversation_id={conversation_id}, table_name={table_name}, "
+        f"column_name={column_name}, object_name={object_name}"
+    )
+
+    sort_by = sort_by if sort_by in ("cost", "tokens") else "recent"
+
+    try:
+        # 1. Object access: table_name / column_name / object_name.
+        object_query = table_name or column_name or object_name
+        if object_query:
+            summary_result = await client.get_access_decision_summary(
+                agent_external_id=agent_external_id,
+            )
+            if summary_result.get("error"):
+                return summary_result
+            summaries = summary_result.get("summaries", [])
+
+            wanted = object_query.lower()
+            matched = [
+                s for s in summaries
+                if wanted in (s.get("tableName") or "").lower()
+                or wanted in (s.get("columnName") or "").lower()
+            ]
+
+            if not matched:
+                return {
+                    "object_query": object_query,
+                    "matched_object_count": 0,
+                    "message": "No AI agent accesses recorded for that object. Object names "
+                               "are matched against the table/column name recorded with the "
+                               "access, so try a shorter fragment, or call the tool with no "
+                               "arguments to see which agents and tables have activity.",
+                }
+
+            objects = [
+                {
+                    "warehouse_name": s.get("warehouseName"),
+                    "schema_name": s.get("schemaName"),
+                    "table_name": s.get("tableName"),
+                    "column_name": s.get("columnName"),
+                    "access_decision_count": s.get("accessDecisionCount"),
+                    "distinct_agent_count": s.get("distinctAgentCount"),
+                    "num_monitors": s.get("numMonitors"),
+                    "num_findings": s.get("numFindings"),
+                    "max_sensitivity": s.get("maxSensitivity"),
+                    "certification_status": s.get("certificationStatus"),
+                }
+                for s in matched
+            ]
+            return {
+                "object_query": object_query,
+                "matched_object_count": len(objects),
+                "objects": objects,
+                "note": "Aggregate counts only; this view cannot attribute accesses to "
+                        "specific users.",
+            }
+
+        # 2. One conversation.
+        if conversation_id is not None:
+            conversation = await client.get_agent_conversation(conversation_id)
+            if conversation.get("error"):
+                return conversation
+            return {"conversation": _conversation_summary_json(conversation)}
+
+        # 3. One user across every agent.
+        if username:
+            conversations_result = await client.list_agent_conversations()
+            if conversations_result.get("error"):
+                return conversations_result
+            conversations = conversations_result.get("agentConversations", [])
+            wanted = username.lower()
+            user_conversations = [
+                c for c in conversations if (c.get("username") or "").lower() == wanted
+            ]
+            if not user_conversations:
+                return {
+                    "username": username,
+                    "conversation_count": 0,
+                    "message": "No agent conversations recorded for this user. Usernames come "
+                               "from the agent platform and are usually email addresses; call "
+                               "the tool with no arguments to list users who do have "
+                               "conversations.",
+                }
+            users = _rollup_users(user_conversations)
+            sorted_conversations = _sort_conversations(user_conversations, sort_by)
+            truncated = sorted_conversations[:max_conversations]
+            return {
+                "user": users[0],
+                "conversation_count": len(user_conversations),
+                "conversations": [_conversation_summary_json(c) for c in truncated],
+                "conversations_truncated": len(user_conversations) > max_conversations,
+                "sorted_by": sort_by,
+            }
+
+        # 4. One agent's conversations and per-user breakdown.
+        resolved_agent_external_id = agent_external_id
+        if not resolved_agent_external_id and agent_id is not None:
+            agents_result = await client.list_ai_agents()
+            if agents_result.get("error"):
+                return agents_result
+            for agent in agents_result.get("aiAgents", []):
+                if agent.get("id") == agent_id:
+                    resolved_agent_external_id = agent.get("externalId")
+                    break
+
+        if resolved_agent_external_id:
+            conversations_result = await client.list_agent_conversations(
+                agent_external_id=resolved_agent_external_id,
+            )
+            if conversations_result.get("error"):
+                return conversations_result
+            conversations = conversations_result.get("agentConversations", [])
+
+            agent_json = None
+            agent_lookup = await client.list_ai_agents()
+            if not agent_lookup.get("error"):
+                for agent in agent_lookup.get("aiAgents", []):
+                    if agent.get("externalId") == resolved_agent_external_id:
+                        agent_json = _agent_summary_json(agent)
+                        break
+            if agent_json is None:
+                agent_json = {"external_id": resolved_agent_external_id}
+
+            sorted_conversations = _sort_conversations(conversations, sort_by)
+            truncated = sorted_conversations[:max_conversations]
+            return {
+                "agent": agent_json,
+                "users": _rollup_users(conversations),
+                "conversation_count": len(conversations),
+                "conversations": [_conversation_summary_json(c) for c in truncated],
+                "conversations_truncated": len(conversations) > max_conversations,
+                "sorted_by": sort_by,
+            }
+
+        # 5. Workspace overview: every agent, every user, and the most
+        # expensive conversations.
+        agents_result = await client.list_ai_agents()
+        if agents_result.get("error"):
+            return agents_result
+        agents = agents_result.get("aiAgents", [])
+
+        conversations_result = await client.list_agent_conversations()
+        if conversations_result.get("error"):
+            return conversations_result
+        conversations = conversations_result.get("agentConversations", [])
+
+        conversations_by_agent: Dict[str, List[Dict[str, Any]]] = {}
+        for conversation in conversations:
+            conversations_by_agent.setdefault(
+                conversation.get("agentExternalId") or "", []
+            ).append(conversation)
+
+        agents_json = []
+        for agent in agents:
+            agent_json = _agent_summary_json(agent)
+            agent_conversations = conversations_by_agent.get(agent.get("externalId") or "", [])
+            total_tokens = sum(c.get("tokenUsage") or 0 for c in agent_conversations)
+            total_cost = sum(c.get("estimatedCost") or 0 for c in agent_conversations)
+            agent_json["conversation_count"] = len(agent_conversations)
+            agent_json["total_token_usage"] = total_tokens
+            agent_json["total_estimated_cost"] = total_cost
+            distinct_tables = {
+                (t.get("id"), t.get("name"))
+                for c in agent_conversations
+                for t in (c.get("summary") or {}).get("tables", [])
+            }
+            agent_json["distinct_accessed_table_count"] = len(distinct_tables)
+            agents_json.append(agent_json)
+
+        top_conversations = _sort_conversations(conversations, "cost")[:10]
+        users_json = _rollup_users(conversations)
+
+        return {
+            "agent_count": len(agents),
+            "agents": agents_json,
+            "user_count": len(users_json),
+            "users": users_json,
+            "conversation_count": len(conversations),
+            "top_conversations_by_cost": [_conversation_summary_json(c) for c in top_conversations],
+            "sorted_by": sort_by,
+        }
+    except Exception as e:
+        return {
+            "error": True,
+            "message": f"Error building AI agent trust hub: {str(e)}"
+        }
+
 @mcp.tool()
 async def get_lineage_graph(
     node_id: int,


### PR DESCRIPTION
## Summary
- Adds a `get_ai_agent_trust_hub` MCP tool reporting on AI agents, the users who talked to them, their conversations, and the tables/columns those conversations accessed — a workspace overview by default, drillable by agent, username, conversation, or table/column name.
- Backed by new `bigeye_api.py` client methods (`list_ai_agents`, `get_ai_agent`, `list_agent_conversations`, `get_agent_conversation`, `get_access_decision_summary`) that call the public `ai-agents`, `agent-conversations`, and `access-decision/summary` REST endpoints, since the internal DAOs backing the equivalent chat-product tool aren't reachable from the MCP server.
- Pins `mcp[cli]` to `<2.0.0` in `pyproject.toml` and `requirements.txt`, since `mcp` 2.0.0 restructured the package and breaks the `mcp.server.fastmcp` import this server relies on.

<img width="557" height="597" alt="image" src="https://github.com/user-attachments/assets/09e58bcd-344c-42a2-b537-a01407c35008" />
<img width="536" height="823" alt="image" src="https://github.com/user-attachments/assets/e04296cf-2aa8-4329-a99a-e5f3a4bde7ff" />
<img width="551" height="828" alt="image" src="https://github.com/user-attachments/assets/db9a50e6-1db0-4e25-83f0-e9dbd364b357" />


## Test plan
- [x] `python3 -m py_compile server.py bigeye_api.py`
- [x] Docker image rebuilds successfully with both `bigeye-mcp-server:latest` / `bigeye-mcp-ephemeral:latest` tags
- [x] Exercise `get_ai_agent_trust_hub` against a real workspace with AI agent activity (no-args overview, agent/username/conversation/table_name branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)